### PR TITLE
Add additional endpoints for OAuth2

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -164,7 +164,9 @@ public class OAuth2ServerConfiguration {
 
         @Override
         public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
-            oauthServer.allowFormAuthenticationForClients();
+            oauthServer.allowFormAuthenticationForClients()
+                       .checkTokenAccess("isAuthenticated()")
+                       .tokenKeyAccess("isAuthenticated()");
         }
 
         @Bean


### PR DESCRIPTION
Add authenticated access to /oauth/check_token and /oauth/token_key. The check_token endpoint allows a client to check the validity of a token. The token_key endpoint allows a client to request the server's public key so JWT signatures can be checked.