### PR TITLE
Disable user role checking in security annotation

### DIFF
--- a/auth-annotation/src/main/java/org/radarcns/security/filter/UserAuthorizationFilter.java
+++ b/auth-annotation/src/main/java/org/radarcns/security/filter/UserAuthorizationFilter.java
@@ -64,12 +64,13 @@ public class UserAuthorizationFilter implements ContainerRequestFilter {
             allowedRoles = extractRoles(resourceClass);
         }
 
+        /* disregard user roles until implementation of project/collection is ready
         try {
             isUserAuthorized(securityContext, allowedRoles, pathParameters);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
-        }
+        }*/
         log.debug("User is authorized for this resource");
     }
 


### PR DESCRIPTION
Disable user role check until implementation for project/collection is ready in rest of the platform