### PR TITLE
Add config to dev profile to let hibernate update the database schema.

### DIFF
--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -45,6 +45,7 @@ spring:
             hibernate.cache.hazelcast.instance_name: ManagementPortal
             hibernate.cache.use_minimal_puts: true
             hibernate.cache.hazelcast.use_lite_member: true
+            hibernate.hbm2ddl.auto: update
     mail:
         host:  # for hotmail
         port:


### PR DESCRIPTION
Otherwise we need to add the sequences we reference in @SequenceGenerator annotations explicitly to Liquibase changelog. For dev environments this solution should be fine.