### PR TITLE
Remove JDBCTokenStore

### DIFF
--- a/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2ServerConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
 import org.springframework.security.oauth2.provider.token.TokenEnhancer;
 import org.springframework.security.oauth2.provider.token.TokenEnhancerChain;
 import org.springframework.security.oauth2.provider.token.TokenStore;
-import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
@@ -51,11 +50,6 @@ public class OAuth2ServerConfiguration {
 
     public OAuth2ServerConfiguration(DataSource dataSource) {
         this.dataSource = dataSource;
-    }
-
-    @Bean
-    public JdbcTokenStore tokenStore() {
-        return new JdbcTokenStore(dataSource);
     }
 
     @Configuration
@@ -219,6 +213,7 @@ public class OAuth2ServerConfiguration {
             DefaultTokenServices defaultTokenServices = new DefaultTokenServices();
             defaultTokenServices.setTokenStore(tokenStore());
             defaultTokenServices.setSupportRefreshToken(true);
+            defaultTokenServices.setReuseRefreshToken(false);
             return defaultTokenServices;
         }
     }

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -1,7 +1,6 @@
 package org.radarcns.management.service;
 
 import java.util.stream.Collectors;
-import javax.validation.constraints.NotNull;
 import org.radarcns.management.domain.Authority;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Role;
@@ -24,7 +23,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,8 +44,6 @@ public class UserService {
 
     private final PasswordEncoder passwordEncoder;
 
-    public final JdbcTokenStore jdbcTokenStore;
-
     private final RoleRepository roleRepository;
 
     private final ProjectMapper projectMapper;
@@ -57,12 +53,11 @@ public class UserService {
     private final RoleMapper roleMapper;
 
     public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder,
-        JdbcTokenStore jdbcTokenStore, RoleRepository roleRepository,
+        RoleRepository roleRepository,
         ProjectRepository projectRepository, ProjectMapper projectMapper,
         UserMapper userMapper, RoleMapper roleMapper) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
-        this.jdbcTokenStore = jdbcTokenStore;
         this.roleRepository = roleRepository;
         this.projectRepository = projectRepository;
         this.projectMapper = projectMapper;
@@ -250,8 +245,6 @@ public class UserService {
     }
 
     public void deleteUser(String login) {
-        jdbcTokenStore.findTokensByUserName(login).forEach(token ->
-            jdbcTokenStore.removeAccessToken(token));
         userRepository.findOneByLogin(login).ifPresent(user -> {
             userRepository.delete(user);
             log.debug("Deleted User: {}", user);


### PR DESCRIPTION
We are using JWT tokens, a JWTTokenStore is defined. We don't need to define a JDBCTokenStore as well. In fact the jdbc token store interferes with proper JWT token operation if they're defined simultaneously.