### PR TITLE
Add Gradle task for OpenAPI spec and Java client

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ For more information refer to [Using Docker and Docker-Compose][], this page als
 
 To configure CI for your project, run the ci-cd sub-generator (`yo jhipster:ci-cd`), this will let you generate configuration files for a number of Continuous Integration systems. Consult the [Setting up Continuous Integration][] page for more information.
 
+## Client libraries
+
+This project provides a Gradle task to generate an [OpenAPI] specification from which client libraries can be automatically generated:
+```bash
+./gradlew generateOpenApiSpec
+```
+The resulting file can be imported into the [Swagger editor], or used with [Swagger codegen] to generate client libraries. A Gradle task for generating a Java client is also provided for convenience:
+```bash
+./gradlew generateJavaClient
+```
+
 [JHipster Homepage and latest documentation]: https://jhipster.github.io
 [JHipster 4.3.0 archive]: https://jhipster.github.io/documentation-archive/v4.3.0
 
@@ -183,3 +194,6 @@ To configure CI for your project, run the ci-cd sub-generator (`yo jhipster:ci-c
 [DefinitelyTyped]: http://definitelytyped.org/
 [Docker]: https://docs.docker.com/
 [Docker-Compose]: https://docs.docker.com/compose/
+[OpenAPI]: https://www.openapis.org/
+[Swagger editor]: http://editor.swagger.io/
+[Swagger codegen]: https://swagger.io/swagger-codegen/

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import groovy.json.JsonSlurper
 import org.gradle.internal.os.OperatingSystem
 
+import java.nio.file.Paths
+
 buildscript {
     repositories {
         mavenLocal()
@@ -17,6 +19,7 @@ buildscript {
         classpath "org.springframework.build.gradle:propdeps-plugin:0.0.7"
         classpath "com.moowork.gradle:gradle-node-plugin:1.1.1"
         classpath "io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE"
+        classpath "io.swagger:swagger-codegen:2.2.3"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
@@ -247,3 +250,37 @@ processResources.dependsOn cleanResources,bootBuildInfo
 bootBuildInfo.mustRunAfter cleanResources
 
 idea.module.downloadSources = true
+
+task generateOpenApiSpec(dependsOn: 'classes') {
+    doLast {
+        String java_home = System.getenv("JAVA_HOME")
+        String java = Paths.get(java_home, "bin", "java").toAbsolutePath()
+        ProcessBuilder pb = new ProcessBuilder(java, "-cp",
+            sourceSets.main.runtimeClasspath.getAsPath(), "org.radarcns.management.ManagementPortalApp")
+        pb.directory(projectDir)
+        File outFile = File.createTempFile("managementportalrun", ".out")
+        // the redirect seems to be necessary for the process to be able to start properly
+        pb.redirectOutput(outFile)
+        Process mp = pb.start()
+        println("Waiting 20s for application to start up")
+        for (int i = 0; i < 20; ++i) {
+            System.out.print("#")
+            System.out.flush()
+            sleep(1000)
+        }
+        println()
+        // Create parent dir to swagger file
+        try {
+            File swaggerFile = new File(Paths.get(projectDir.absolutePath, swaggerFileLocation).toString());
+            swaggerFile.getParentFile().mkdirs();
+            ProcessBuilder curlPb = new ProcessBuilder("curl", apiDocsEndpoint, "-o",
+                swaggerFileLocation)
+            curlPb.directory(projectDir)
+            curlPb.start().waitFor()
+        }
+        finally {
+            mp.waitForOrKill(1)
+            outFile.delete()
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,7 @@ task generateJavaClient(dependsOn: 'generateOpenApiSpec', group: 'Swagger',
     doLast {
         def config = new CodegenConfigurator()
         config.setInputSpec(Paths.get(projectDir.absolutePath, swaggerFileLocation).toString())
-        config.setOutputDir(swaggerTargetFolder)
+        config.setOutputDir(Paths.get(projectDir.absolutePath, swaggerTargetFolder).toString())
         config.setLang("java")
         config.setArtifactId("managementportal-client")
         config.setGroupId("org.radarcns")

--- a/build.gradle
+++ b/build.gradle
@@ -301,13 +301,18 @@ task generateJavaClient(dependsOn: 'generateOpenApiSpec', group: 'Swagger',
     inputs.file(swaggerFileLocation)
     outputs.dir(swaggerTargetFolder)
     doLast {
+        // if gradle determined this task is out of date, first delete the directory
+        File targetFolder = new File(projectDir.absolutePath, swaggerTargetFolder)
+        if (targetFolder.exists()) {
+            targetFolder.deleteDir()
+        }
         def config = new CodegenConfigurator()
         config.setInputSpec(Paths.get(projectDir.absolutePath, swaggerFileLocation).toString())
         config.setOutputDir(Paths.get(projectDir.absolutePath, swaggerTargetFolder).toString())
         config.setLang("java")
         config.setArtifactId("managementportal-client")
         config.setGroupId("org.radarcns")
-        config.setArtifactVersion("1.0.0")
+        config.setArtifactVersion(version)
         config.setAdditionalProperties([
             'apiPackage'   : 'org.radarcns.management.client.api',
             'modelPackage' : 'org.radarcns.management.client.model',

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import groovy.json.JsonSlurper
 import org.gradle.internal.os.OperatingSystem
+import io.swagger.codegen.config.CodegenConfigurator
+import io.swagger.codegen.DefaultGenerator
 
 import java.nio.file.Paths
 
@@ -19,7 +21,7 @@ buildscript {
         classpath "org.springframework.build.gradle:propdeps-plugin:0.0.7"
         classpath "com.moowork.gradle:gradle-node-plugin:1.1.1"
         classpath "io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE"
-        classpath "io.swagger:swagger-codegen:2.2.3"
+        classpath "io.swagger:swagger-codegen:2.2.2"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
@@ -251,7 +253,9 @@ bootBuildInfo.mustRunAfter cleanResources
 
 idea.module.downloadSources = true
 
-task generateOpenApiSpec(dependsOn: 'classes') {
+task generateOpenApiSpec(dependsOn: 'classes', group: 'Swagger',
+        description: 'Runs the application to fetch the OpenAPI spec from the Swagger endpoint') {
+    outputs.file(swaggerFileLocation)
     doLast {
         String java_home = System.getenv("JAVA_HOME")
         String java = Paths.get(java_home, "bin", "java").toAbsolutePath()
@@ -262,25 +266,54 @@ task generateOpenApiSpec(dependsOn: 'classes') {
         // the redirect seems to be necessary for the process to be able to start properly
         pb.redirectOutput(outFile)
         Process mp = pb.start()
-        println("Waiting 20s for application to start up")
-        for (int i = 0; i < 20; ++i) {
-            System.out.print("#")
-            System.out.flush()
-            sleep(1000)
-        }
-        println()
+
         // Create parent dir to swagger file
+        File swaggerFile = new File(swaggerFileLocation);
+        swaggerFile.getParentFile().mkdirs();
+
+        def generated = false
+        println("Waiting for application to start up")
         try {
-            File swaggerFile = new File(Paths.get(projectDir.absolutePath, swaggerFileLocation).toString());
-            swaggerFile.getParentFile().mkdirs();
-            ProcessBuilder curlPb = new ProcessBuilder("curl", apiDocsEndpoint, "-o",
-                swaggerFileLocation)
-            curlPb.directory(projectDir)
-            curlPb.start().waitFor()
+            // try once every second to see if the application has started up
+            while (!generated) {
+                System.out.print("#")
+                System.out.flush()
+                ProcessBuilder curlPb = new ProcessBuilder("curl", apiDocsEndpoint, "-o",
+                    swaggerFileLocation, "--connect-timeout", "1")
+                curlPb.directory(projectDir)
+                Process curlProcess = curlPb.start()
+                curlProcess.waitFor()
+                generated = curlProcess.exitValue() == 0
+            }
+            println()
+            println("Swagger file generated at " + swaggerFileLocation)
         }
         finally {
+            // stop the managementportal process
             mp.waitForOrKill(1)
             outFile.delete()
         }
+    }
+}
+
+task generateJavaClient(dependsOn: 'generateOpenApiSpec', group: 'Swagger',
+        description: 'Generate a Java client library for ManagementPortal') {
+    inputs.file(swaggerFileLocation)
+    outputs.dir(swaggerTargetFolder)
+    doLast {
+        def config = new CodegenConfigurator()
+        config.setInputSpec(Paths.get(projectDir.absolutePath, swaggerFileLocation).toString())
+        config.setOutputDir(swaggerTargetFolder)
+        config.setLang("java")
+        config.setArtifactId("managementportal-client")
+        config.setGroupId("org.radarcns")
+        config.setArtifactVersion("1.0.0")
+        config.setAdditionalProperties([
+            'apiPackage'   : 'org.radarcns.management.client.api',
+            'modelPackage' : 'org.radarcns.management.client.model',
+
+        ])
+        new DefaultGenerator().opts(config.toClientOptInput()).generate()
+        println("Client generated at " + swaggerTargetFolder)
     }
 }

--- a/gradle/profile_dev.gradle
+++ b/gradle/profile_dev.gradle
@@ -1,12 +1,11 @@
-import org.gradle.internal.os.OperatingSystem
-
 apply plugin: 'org.springframework.boot'
 apply plugin: 'com.moowork.node'
 
 ext {
     logbackLoglevel = "DEBUG"
     apiDocsEndpoint = "http://localhost:8080/v2/api-docs"
-    swaggerFileLocation = "build/swagger/swagger.json"
+    swaggerFileLocation = "build/swagger-spec/swagger.json"
+    swaggerTargetFolder = "build/managementportal-client"
 }
 
 dependencies {

--- a/gradle/profile_dev.gradle
+++ b/gradle/profile_dev.gradle
@@ -5,6 +5,8 @@ apply plugin: 'com.moowork.node'
 
 ext {
     logbackLoglevel = "DEBUG"
+    apiDocsEndpoint = "http://localhost:8080/v2/api-docs"
+    swaggerFileLocation = "build/swagger/swagger.json"
 }
 
 dependencies {


### PR DESCRIPTION
- Add Gradle task for generating the OpenAPI specification of the ManagementPortal API. It is by default only available when the application is running at `/v2/api-docs`. The Gradle task to generate it is `generateOpenApiSpec`
- Add Gradle task for generating a Java client based on the OpenAPI spec using swagger-codegen. The Gradle task is `generateJavaClient`