### PR TITLE
Add necessary variables to Gradle production profile

### DIFF
--- a/gradle/profile_prod.gradle
+++ b/gradle/profile_prod.gradle
@@ -3,6 +3,9 @@ apply plugin: 'com.moowork.node'
 
 ext {
     logbackLoglevel = "INFO"
+    apiDocsEndpoint = "http://localhost:8080/v2/api-docs"
+    swaggerFileLocation = "build/swagger-spec/swagger.json"
+    swaggerTargetFolder = "build/managementportal-client"
 }
 
 dependencies {


### PR DESCRIPTION
Some variables for the OpenAPI spec Gradle task were not available in the production profile, preventing tasks to be run in the production profile.