### PR TITLE
Api test

### DIFF
--- a/src/main/java/org/radarcns/management/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/org/radarcns/management/web/rest/errors/ExceptionTranslator.java
@@ -13,6 +13,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * Controller advice to translate the server side exceptions to client-friendly json structures.
@@ -38,6 +39,14 @@ public class ExceptionTranslator {
             dto.add(fieldError.getObjectName(), fieldError.getField(), fieldError.getCode());
         }
         return dto;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorVM processValidationError(MethodArgumentTypeMismatchException ex) {
+        return new ErrorVM(ErrorConstants.ERR_VALIDATION,
+            ex.getName() + ": " + ex.getMessage());
     }
 
     @ExceptionHandler(CustomParameterizedException.class)

--- a/src/main/resources/config/liquibase/test_users.csv
+++ b/src/main/resources/config/liquibase/test_users.csv
@@ -1,7 +1,7 @@
 "ID";"LOGIN";"PASSWORD_HASH";"FIRST_NAME";"LAST_NAME";"EMAIL";"ACTIVATED";"LANG_KEY";"CREATED_BY";"LAST_MODIFIED_BY"
 1;admin;$2a$10$gSAhZrxMllrbgj/kkK9UceBPpChGWJA7SYIb1Mqo.n5aNLq1/oRrC;Administrator;Administrator;admin@localhost;true;en;system;system
 2;"sub-1";"$2a$10$W0hhdkD2trCgPuUo4pZNkeKcIvE0tw/5mmxDQtVik9s2dFclx..n6";NULL;NULL;"sub-1@localhost";"false";"en";"admin";"admin"
-3;"sub-2";"$2a$10$M3JF7z1F/tCitgUJL.eOU.EEPiFBDQ7huXoFCfDodfsNScuX8sjy.";NULL;NULL;"sub-2@localhost";"false";"en";"admin";"admin"
+3;"sub-2";"$2a$10$M3JF7z1F/tCitgUJL.eOU.EEPiFBDQ7huXoFCfDodfsNScuX8sjy.";NULL;NULL;"sub-2@localhost";"true";"en";"admin";"admin"
 4;"sub-3";"$2a$10$BAydwSFZF22cEYAB29Q9C.WK9PS1Z3c8V.h0AUB9KQEb18AGeNCi2";NULL;NULL;"sub-3@localhost";"false";"en";"admin";"admin"
 5;padmin;$2a$10$aIewJVA1C7hJDVYIGQSJ5.6bk/vD85tvGIJe2I52H02m2qN4HBQ9S;null;null;padmin@localhost;TRUE;en;system;system
 6;padmin2;$2a$10$aIewJVA1C7hJDVYIGQSJ5.6bk/vD85tvGIJe2I52H02m2qN4HBQ9S;null;null;padmin2@localhost;TRUE;en;admin;system


### PR DESCRIPTION
- Enabled `sub-2` test user
- Give proper HTTP status code on wrong parameter type, e.g.,
`GET /api/subjects/mysubjectname`
gave:
```json
{
  "message" : "error.internalServerError",
  "description" : "Internal server error",
  "fieldErrors" : null
}
```
and now gives:
```
{
  "message" : "error.validation",
  "description" : "id: Failed to convert value of type 'java.lang.String' to required type 'java.lang.Long'; nested exception is java.lang.NumberFormatException: For input string: \"aba\"",
  "fieldErrors" : null
}
```