### PR TITLE
Add environment variable to docker container of MP for java options

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -10,4 +10,4 @@ VOLUME /tmp
 EXPOSE 8080 5701/udp
 CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
     sleep ${JHIPSTER_SLEEP} && \
-    java -Djava.security.egd=file:/dev/./urandom -jar /app.war
+    java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.war

--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -6,6 +6,7 @@ services:
             - SPRING_PROFILES_ACTIVE=prod,swagger
             - SPRING_DATASOURCE_URL=jdbc:postgresql://managementportal-postgresql:5432/managementportal
             - JHIPSTER_SLEEP=10 # gives time for the database to boot before the application
+            - JAVA_OPTS="-Xmx256m"  # maximum heap size for the JVM running ManagementPortal, increase this as necessary
         ports:
             - 8080:8080
     managementportal-postgresql:


### PR DESCRIPTION
This allows to easily tune the JVM options inside the docker container, allowing for e.g. memory tuning and optimization strategy