### PR TITLE
Deactivate discontinued subject

### DIFF
--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -174,7 +174,10 @@ public class SubjectService {
             sourceRepository.save(source);
         }
 
+        // set the removed flag and deactivate the user to prevent them from refreshing their
+        // access token
         subject.setRemoved(true);
+        subject.getUser().setActivated(false);
         return subjectMapper.subjectToSubjectDTO(subjectRepository.save(subject));
     }
 

--- a/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
@@ -17,10 +17,11 @@ import javax.validation.constraints.Size;
 public class SubjectDTO implements Serializable {
 
     public enum SubjectStatus {
-        DEACTIVATED, // activated = false, removed=false
-        ACTIVATED, //activated = true, removed=false
-        DISCONTINUED // activated = true, removed = true
-         }
+        DEACTIVATED,    // activated = false, removed = false
+        ACTIVATED,      // activated = true,  removed = false
+        DISCONTINUED,   // activated = false, removed = true
+        INVALID         // activated = true,  removed = true (invalid state, makes no sense)
+    }
 
     public static final String HUMAN_READABLE_IDENTIFIER_KEY = "Human-readable-identifier";
 

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -99,16 +99,16 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
     }
 
     private SubjectStatus getSubjectStatus(Subject subject) {
-        if(!subject.getUser().getActivated() && !subject.isRemoved()) {
+        if (!subject.getUser().getActivated() && !subject.isRemoved()) {
             return SubjectStatus.DEACTIVATED;
         }
-        else if( subject.getUser().getActivated() && !subject.isRemoved()) {
+        else if (subject.getUser().getActivated() && !subject.isRemoved()) {
             return SubjectStatus.ACTIVATED;
         }
-        else if(subject.isRemoved()) {
+        else if (!subject.getUser().getActivated() && subject.isRemoved()) {
             return SubjectStatus.DISCONTINUED;
         }
-        return SubjectStatus.DEACTIVATED;
+        return SubjectStatus.INVALID;
     }
 
     private Subject setSubjectStatus (SubjectDTO subjectDTO, Subject subject) {
@@ -122,9 +122,12 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
                 subject.setRemoved(false);
                 break;
             case DISCONTINUED:
+                subject.getUser().setActivated(false);
                 subject.setRemoved(true);
                 break;
-
+            case INVALID:
+                subject.getUser().setActivated(true);
+                subject.setRemoved(true);
         }
         return subject;
     }

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -68,16 +68,17 @@ export class UserMgmtComponent implements OnInit, OnDestroy {
         user.activated = isActivated;
 
         this.userService.update(user).subscribe(
-            (response) => {
-                if (response.status === 200) {
+            (res: Response) => {
                     this.error = null;
                     this.success = 'OK';
                     this.loadAll();
-                } else {
+                },
+            (res: Response) => {
+                    user.activated = !isActivated;
                     this.success = null;
                     this.error = 'ERROR';
-                }
-            });
+                    this.onError(res.json());
+                });
     }
 
     loadAll() {
@@ -127,6 +128,6 @@ export class UserMgmtComponent implements OnInit, OnDestroy {
     }
 
     private onError(error) {
-        this.alertService.error(error.error, error.message, null);
+        this.alertService.error(error.message, null, null);
     }
 }

--- a/src/main/webapp/app/shared/subject/subject.component.html
+++ b/src/main/webapp/app/shared/subject/subject.component.html
@@ -52,6 +52,7 @@
                     <span class="badge badge-danger" *ngIf="subject.status == 'DEACTIVATED'">DEACTIVATED</span>
                     <span class="badge badge-success" *ngIf="subject.status == 'ACTIVATED'">ACTIVATED</span>
                     <span class="badge badge-warning" *ngIf="subject.status == 'DISCONTINUED'">DISCONTINUED</span>
+                    <span class="badge badge-danger" *ngIf="subject.status == 'INVALID'">INVALID</span>
                 </td>
                 <td  *ngIf="!isProjectSpecific">
                     <div *ngIf="subject.project">
@@ -70,7 +71,7 @@
                 </td>
                 <td class="text-right">
                     <div class="btn-group flex-btn-group-container">
-                        <button [disabled]="subject.status == 'DISCONTINUED'"
+                        <button [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'subject/' + subject.login + '/pairApp' } }]"
                                 replaceUrl="true"
@@ -78,7 +79,7 @@
                             <span class="fa fa-qrcode"></span>
                             <span jhiTranslate="managementPortalApp.subject.pairApp">Pair App</span>
                         </button>
-                        <button [disabled]="subject.status == 'DISCONTINUED'"
+                        <button [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'subject/' + subject.login + '/sources' } }]"
                                 replaceUrl="true"
@@ -90,14 +91,14 @@
                 </td>
                 <td class="text-right">
                     <div class="btn-group flex-btn-group-container">
-                        <button *ngIf='!isProjectSpecific' [disabled]="subject.status == 'DISCONTINUED'"
+                        <button *ngIf='!isProjectSpecific' [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/subject', subject.login ]"
                                 class="btn btn-info btn-sm">
                             <span class="fa fa-eye"></span>
                             <span class="hidden-md-down" jhiTranslate="entity.action.view">View</span>
                         </button>
-                        <button *ngIf='!isProjectSpecific' [disabled]="subject.status == 'DISCONTINUED'"
+                        <button *ngIf='!isProjectSpecific' [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'general-subject/'+ subject.login + '/edit'} }]"
                                 replaceUrl="true"
@@ -105,7 +106,7 @@
                             <span class="fa fa-pencil"></span>
                             <span class="hidden-md-down" jhiTranslate="entity.action.edit">Edit</span>
                         </button>
-                        <button *ngIf='isProjectSpecific' [disabled]="subject.status == 'DISCONTINUED'"
+                        <button *ngIf='isProjectSpecific' [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'project-subject/'+ project.id + '/' +subject.login + '/edit'} }]"
                                 replaceUrl="true"
@@ -113,7 +114,7 @@
                             <span class="fa fa-pencil"></span>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
                         </button>
                         <button
-                                [disabled]="subject.status == 'DISCONTINUED'"
+                                [disabled]="subject.status != 'ACTIVATED'"
                                 type="submit"
                                 [routerLink]="['/', { outlets: { popup: 'subject/'+ subject.login + '/discontinue'} }]"
                                 replaceUrl="true"

--- a/src/main/webapp/app/shared/subject/subject.model.ts
+++ b/src/main/webapp/app/shared/subject/subject.model.ts
@@ -48,5 +48,6 @@ export class Subject {
 export const enum SubjectStatus {
     'DEACTIVATED',
     'ACTIVATED',
-    'DISCONTINUED'
+    'DISCONTINUED',
+    'INVALID'
 }

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -143,7 +143,8 @@
         "Size": "Field {{ fieldName }} does not meet min/max size requirements!",
         "userexists": "Login name already used!",
         "emailexists": "Email is already in use!",
-        "idexists": "A new {{ entityName }} cannot already have an ID"
+        "idexists": "A new {{ entityName }} cannot already have an ID",
+        "invalidsubjectstate": "A discontinued subject can not be activated"
     },
     "footer": "For more details, read the user guide <a target=\"_blank\" href=\"https://github.com/RADAR-CNS/ManagementPortal/wiki/User-Guide\">here.</a>"
 }

--- a/src/main/webapp/i18n/en/subject.json
+++ b/src/main/webapp/i18n/en/subject.json
@@ -51,7 +51,8 @@
                 "title" : "Status",
                 "discontinued" : "DISCONTINUED",
                 "active" : "ACTIVATED",
-                "deactivated" : "DEACTIVATED"
+                "deactivated" : "DEACTIVATED",
+                "invalid": "INVALID"
             },
             "discontinue" : {
                 "operation" : "Discontinue",

--- a/src/main/webapp/i18n/nl/global.json
+++ b/src/main/webapp/i18n/nl/global.json
@@ -127,8 +127,8 @@
         "Size": "Field {{fieldName}} does not meet min/max size requirements!",
         "userexists": "Login name already used!",
         "emailexists": "Email is already in use!",
-        "idexists": "A new {{entityName}} cannot already have an ID"
-
+        "idexists": "A new {{entityName}} cannot already have an ID",
+        "invalidsubjectstate": "Een stopgezette deelnemer kan niet geactiveerd worden"
     },
     "footer": "Dit is uw voettekst"
 }

--- a/src/main/webapp/i18n/nl/subject.json
+++ b/src/main/webapp/i18n/nl/subject.json
@@ -51,7 +51,8 @@
                 "title" : "Staat",
                 "discontinued" : "Stopgezet",
                 "active" : "Geactiveerd",
-                "deactivated" : "Gedeactiveerd"
+                "deactivated" : "Gedeactiveerd",
+                "invalid": "Ongeldig"
             },
             "discontinue" : {
                 "operation" : "Staken",

--- a/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.management.ManagementPortalApp;
 import org.radarcns.management.domain.User;
+import org.radarcns.management.repository.SubjectRepository;
 import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.security.JwtAuthenticationFilter;
 import org.radarcns.management.service.MailService;
@@ -96,6 +97,9 @@ public class UserResourceIntTest {
     private EntityManager em;
 
     @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Autowired
     private HttpServletRequest servletRequest;
 
     private MockMvc restUserMockMvc;
@@ -109,6 +113,7 @@ public class UserResourceIntTest {
         ReflectionTestUtils.setField(userResource, "userService", userService);
         ReflectionTestUtils.setField(userResource, "mailService", mailService);
         ReflectionTestUtils.setField(userResource, "userRepository", userRepository);
+        ReflectionTestUtils.setField(userResource, "subjectRepository", subjectRepository);
         ReflectionTestUtils.setField(userResource, "servletRequest", servletRequest);
 
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter();


### PR DESCRIPTION
- Deactivate the user associated to a discontinued subject to prevent from logging in to the system
- The combinations of activated and removed states had names only for 3 of the 4 possible combinations, so added one there with the name 'INVALID', since an activated user for a removed subject does not seem to make sense
- Prevent activating the user related to a discontinued subject

Closes #80