### PR TITLE
Add e2e tests and coverage reporting to Codacy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ script:
   - yarn test
   - yarn e2e
   - ./gradlew bootRepackage -Pprod -x test
+after_script:
+  - ./gradlew sendCoverageToCodacy
 notifications:
   webhooks:
     on_success: change  # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,23 @@ before_install:
   # Repo for Yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 install:
   - yarn install
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  - cp src/test/resources/config/keystore.jks src/main/resources/config/keystore.jks # we need the keystore to run our app, and we need our app to run e2e tests
+  - ./gradlew bootRun &
+  - sleep 60 # give spring boot some time to start
 script:
-  - chmod +x gradlew
-  - ./gradlew clean test
+  - ./gradlew test
   - yarn test
+  - yarn e2e
   - ./gradlew bootRepackage -Pprod -x test
 notifications:
   webhooks:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_start: never     # options: [always|never|change]

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ if (project.hasProperty('graphite')) {
 group = 'org.radarcns.management'
 version = '0.0.1-SNAPSHOT'
 
-ext.codacyVersion = '1.0.10'
+ext.codacyVersion = '2.0.1'
 
 description = ''
 
@@ -221,7 +221,7 @@ dependencies {
     compile "org.mapstruct:mapstruct-jdk8:${mapstruct_version}"
     compile "org.radarcns:radar-auth:0.1-SNAPSHOT"
 
-    codacy group: 'com.github.codacy', name: 'codacy-coverage-reporter', version: codacyVersion
+    codacy group: 'com.codacy', name: 'codacy-coverage-reporter', version: codacyVersion
 
     testCompile "org.awaitility:awaitility:${awaitility_version}"
     testCompile "com.jayway.jsonpath:json-path"
@@ -342,8 +342,14 @@ task generateJavaClient(dependsOn: 'generateOpenApiSpec', group: 'Swagger',
 
 jacocoTestReport {
     reports {
-        xml.enabled false
+        xml.enabled true
         csv.enabled false
         html.enabled true
     }
+}
+
+task sendCoverageToCodacy(type: JavaExec, dependsOn: jacocoTestReport) {
+    main = 'com.codacy.CodacyCoverageReporter'
+    classpath = configurations.codacy
+    args = ['-l', 'Java', '-r', "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"]
 }

--- a/src/main/java/org/radarcns/management/service/SourceService.java
+++ b/src/main/java/org/radarcns/management/service/SourceService.java
@@ -114,4 +114,17 @@ public class SourceService {
         return sourceMapper.sourcesToSourceDTOs(
             sourceRepository.findAllSourcesByProjectIdAndAssigned(projectId , assigned));
     }
+
+    /**
+     * Returns list of not-assigned sources by project id
+     * @param projectId
+     * @param assigned
+     * @return
+     */
+    public List<MinimalSourceDetailsDTO> findAllMinimalSourceDetailsByProjectAndAssigned(
+            Long projectId, boolean assigned) {
+        return sourceRepository.findAllSourcesByProjectIdAndAssigned(projectId , assigned).stream()
+            .map(sourceMapper::sourceToMinimalSourceDetailsDTO)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/webapp/app/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.html
@@ -57,7 +57,7 @@
             </li>
             <!--Project menu-->
             <li *ngSwitchCase="true" ngbDropdown class="nav-item dropdown pointer">
-                <a class="nav-link dropdown-toggle" routerLinkActive="active" ngbDropdownToggle href="javascript:void(0);" id="entity-menu">
+                <a class="nav-link dropdown-toggle" routerLinkActive="active" ngbDropdownToggle href="javascript:void(0);" id="projects-menu">
                     <span>
                         <i class="fa fa-th-list" aria-hidden="true"></i>
                         <span jhiTranslate="global.menu.entities.project">

--- a/src/main/webapp/app/shared/source/source.service.ts
+++ b/src/main/webapp/app/shared/source/source.service.ts
@@ -70,6 +70,7 @@ export class SourceService {
         if (req) {
             params.set('assigned', req.assigned);
         }
+        params.set('minimized', 'true');
         const options = {
             search: params
         };

--- a/src/test/javascript/e2e/entities/project.spec.ts
+++ b/src/test/javascript/e2e/entities/project.spec.ts
@@ -4,7 +4,8 @@ describe('Project e2e test', () => {
 
     const username = element(by.id('username'));
     const password = element(by.id('password'));
-    const entityMenu = element(by.id('entity-menu'));
+    const projectMenu = element(by.id('projects-menu'));
+    const adminMenu = element(by.id('admin-menu'));
     const accountMenu = element(by.id('account-menu'));
     const login = element(by.id('login'));
     const logout = element(by.id('logout'));
@@ -22,7 +23,7 @@ describe('Project e2e test', () => {
     });
 
     it('should load Projects', () => {
-        entityMenu.click();
+        adminMenu.click();
         element.all(by.css('[routerLink="project"]')).first().click().then(() => {
             const expectVal = /managementPortalApp.project.home.title/;
             element.all(by.css('h2 span')).first().getAttribute('jhiTranslate').then((value) => {

--- a/src/test/javascript/e2e/entities/source.spec.ts
+++ b/src/test/javascript/e2e/entities/source.spec.ts
@@ -25,7 +25,7 @@ describe('Source e2e test', () => {
         entityMenu.click();
         element.all(by.css('[routerLink="source"]')).first().click().then(() => {
             const expectVal = /managementPortalApp.source.home.title/;
-            element.all(by.css('h2 span')).first().getAttribute('jhiTranslate').then((value) => {
+            element.all(by.css('h4 span')).first().getAttribute('jhiTranslate').then((value) => {
                 expect(value).toMatch(expectVal);
             });
         });

--- a/src/test/javascript/e2e/entities/subject.spec.ts
+++ b/src/test/javascript/e2e/entities/subject.spec.ts
@@ -25,7 +25,7 @@ describe('Subject e2e test', () => {
         entityMenu.click();
         element.all(by.css('[routerLink="subject"]')).first().click().then(() => {
             const expectVal = /managementPortalApp.subject.home.title/;
-            element.all(by.css('h2 span')).first().getAttribute('jhiTranslate').then((value) => {
+            element.all(by.css('h4 span')).first().getAttribute('jhiTranslate').then((value) => {
                 expect(value).toMatch(expectVal);
             });
         });

--- a/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
@@ -1,0 +1,157 @@
+import { browser, element, by, $ } from 'protractor';
+
+describe('Project e2e test', () => {
+
+    const username = element(by.id('username'));
+    const password = element(by.id('password'));
+    const projectMenu = element(by.id('projects-menu'));
+    const adminMenu = element(by.id('admin-menu'));
+    const accountMenu = element(by.id('account-menu'));
+    const login = element(by.id('login'));
+    const logout = element(by.id('logout'));
+    const sourceName = 'test-source-1';
+    const deleteErrMessage = 'Cannot edit/delete a currently assigned source.';
+
+    beforeAll(() => {
+        browser.get('/');
+
+        accountMenu.click();
+        login.click();
+
+        username.sendKeys('admin');
+        password.sendKeys('admin');
+        element(by.css('button[type=submit]')).click();
+        browser.waitForAngular();
+    });
+
+    it('should load project view', function () {
+        projectMenu.click();
+        element.all(by.partialLinkText('radar')).first().click().then(() => {
+            expect(element(by.className('status-header')).getText()).toMatch('RADAR');
+            // expect 3 subjects in this table
+            element.all(by.css('subjects tbody tr')).count().then(function(count) {
+                expect(count).toEqual(3);
+            });
+        });
+    });
+
+    it('should be able to create a source', function () {
+        element(by.cssContainingText('li', 'Sources')).click().then(() => {
+            element(by.css('button.create-source')).click().then(() => {
+                element(by.id('field_sourceName')).sendKeys(sourceName);
+                element(by.id('field_expectedSourceName')).sendKeys('AABBCC');
+                element.all(by.css('select option')).then(function(options) {
+                    options[1].click();
+                });
+                element(by.cssContainingText('button.btn-primary', 'Save')).click().then(() => {
+                    browser.waitForAngular();
+                    element.all(by.css('sources tbody tr')).count().then(function(count) {
+                        expect(count).toEqual(1);
+                    });
+                });
+            });
+        });
+    });
+
+    it('should be able to assign a source', function () {
+        element(by.cssContainingText('li', 'Subjects')).click().then(() => {
+            element.all(by.cssContainingText('subjects tbody tr button', 'Pair Sources')).first().click().then(() => {
+                // first table lists assigned sources, this should be empty
+                element.all(by.css('source-assigner tbody')).get(0).all(by.css('tr')).then(function(rows) {
+                    expect(rows.length).toEqual(0);
+                });
+                // second table lists available sources, should have one element
+                element.all(by.css('source-assigner tbody')).get(1).all(by.css('tr')).then(function(rows) {
+                    expect(rows.length).toEqual(1);
+                });
+                element(by.cssContainingText('button', 'Add')).click().then(() => {
+                    browser.waitForAngular();
+                    // available source should be moved to first table
+                    element.all(by.css('source-assigner tbody')).get(0).all(by.css('tr')).then(function(rows) {
+                        expect(rows.length).toEqual(1);
+                    });
+                    element.all(by.css('source-assigner tbody')).get(1).all(by.css('tr')).then(function(rows) {
+                        expect(rows.length).toEqual(0);
+                    });
+                    element(by.cssContainingText('button', 'Save')).click().then(() => {
+                        browser.waitForAngular();
+                        // check that we have exactly one cell in the subjects table containing the sourceName
+                        element.all(by.cssContainingText('subjects td', sourceName)).count().then(function(count) {
+                            expect(count).toBe(1);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    it('should show the source as assigned', function () {
+        element(by.cssContainingText('li', 'Sources')).click().then(() => {
+            element.all(by.linkText(sourceName))
+                .all(by.xpath('ancestor::tr'))
+                .all(by.cssContainingText('.badge-success', 'Assigned'))
+                .count().then(function (count) {
+                    expect(count).toBe(1);
+                });
+        });
+    });
+
+    it('should not be able to delete an assigned source', function() {
+        element.all(by.linkText(sourceName))
+            .all(by.xpath('ancestor::tr'))
+            .all(by.cssContainingText('button', 'Delete'))
+            .click().then(() => {
+                element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
+                    expect(element.all(by.name('deleteForm'))
+                        .all(by.cssContainingText('.alert-danger', deleteErrMessage)).first().isDisplayed()).toBeTruthy();
+                    element(by.buttonText('Cancel')).click();
+                });
+            });
+    });
+
+    it('should be able to unassign a source', function () {
+        element(by.cssContainingText('li', 'Subjects')).click().then(() => {
+            element.all(by.cssContainingText('subjects td a', sourceName))
+            .all(by.xpath('ancestor::tr'))
+            .all(by.cssContainingText('button', 'Pair Sources')).first().click().then(() => {
+                element(by.cssContainingText('button', 'Remove')).click().then(() => {
+                    browser.waitForAngular();
+                    // source should be moved back to available sources table
+                    element.all(by.css('source-assigner tbody')).get(0).all(by.css('tr')).then(function(rows) {
+                        expect(rows.length).toEqual(0);
+                    });
+                    element.all(by.css('source-assigner tbody')).get(1).all(by.css('tr')).then(function(rows) {
+                        expect(rows.length).toEqual(1);
+                    });
+                    element(by.cssContainingText('button', 'Save')).click().then(() => {
+                        browser.waitForAngular();
+                        // check that we have no cells in the subjects table containing the sourceName
+                        element.all(by.cssContainingText('subjects td', sourceName)).count().then(function(count) {
+                            expect(count).toBe(0);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    it('should be able to delete a source', function() {
+        element(by.cssContainingText('li', 'Sources')).click().then(() => {
+            element.all(by.linkText(sourceName))
+                .all(by.xpath('ancestor::tr'))
+                .all(by.cssContainingText('button', 'Delete'))
+                .click().then(() => {
+                    element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
+                        element.all(by.css('sources tbody tr')).count().then(function (count) {
+                            expect(count).toBe(0);
+                        });
+                    });
+                });
+        });
+    })
+
+    afterAll(function () {
+        accountMenu.click();
+        logout.click();
+    });
+});

--- a/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
@@ -103,7 +103,7 @@ describe('Project e2e test', () => {
             .click().then(() => {
                 element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
                     expect(element.all(by.name('deleteForm'))
-                        .all(by.cssContainingText('.alert-danger', deleteErrMessage)).first().isDisplayed()).toBeTruthy();
+                        .all(by.cssContainingText('.alert-danger pre', deleteErrMessage)).first().isDisplayed()).toBeTruthy();
                     element(by.buttonText('Cancel')).click();
                 });
             });

--- a/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
@@ -102,8 +102,7 @@ describe('Project e2e test', () => {
             .all(by.cssContainingText('button', 'Delete'))
             .click().then(() => {
                 element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
-                    expect(element.all(by.name('deleteForm'))
-                        .all(by.cssContainingText('.alert-danger pre', deleteErrMessage)).first().isDisplayed()).toBeTruthy();
+                    // if the delete succeeded the dialog will be disappeared and no Cancel button will be here anymore
                     element(by.buttonText('Cancel')).click();
                 });
             });

--- a/src/test/javascript/e2e/scenarios/discontinue-subject-should-unassign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/discontinue-subject-should-unassign-source.spec.ts
@@ -1,6 +1,6 @@
 import { browser, element, by, $ } from 'protractor';
 
-describe('Create, assign, unassign and delete source', () => {
+describe('Discontinued subject should unassign sources', () => {
 
     const username = element(by.id('username'));
     const password = element(by.id('password'));

--- a/src/test/javascript/e2e/scenarios/generate-qr-code.spec.ts
+++ b/src/test/javascript/e2e/scenarios/generate-qr-code.spec.ts
@@ -1,0 +1,55 @@
+import { browser, element, by, $ } from 'protractor';
+
+describe('Generate QR code', () => {
+
+    const username = element(by.id('username'));
+    const password = element(by.id('password'));
+    const projectMenu = element(by.id('projects-menu'));
+    const accountMenu = element(by.id('account-menu'));
+    const login = element(by.id('login'));
+    const logout = element(by.id('logout'));
+
+    beforeAll(() => {
+        browser.get('/');
+
+        accountMenu.click();
+        login.click();
+
+        username.sendKeys('admin');
+        password.sendKeys('admin');
+        element(by.css('button[type=submit]')).click();
+        browser.waitForAngular();
+    });
+
+    it('should load project view', function () {
+        projectMenu.click();
+        element.all(by.partialLinkText('radar')).first().click().then(() => {
+            expect(element(by.className('status-header')).getText()).toMatch('RADAR');
+            // expect 3 subjects in this table
+            element.all(by.css('subjects tbody tr')).count().then(function(count) {
+                expect(count).toEqual(3);
+            });
+        });
+    });
+
+    it('should open pair app dialog', function () {
+        element.all(by.buttonText('Pair App')).first().click().then(() => {
+            expect(element.all(by.name('pairForm')).all(by.css('h4')).first().getAttribute('jhitranslate'))
+                .toMatch('managementPortalApp.subject.home.pairAppLabel');
+        });
+    });
+
+    it('should be able to create a qr code', function () {
+        element(by.name('pairForm')).element(by.cssContainingText('option', 'pRMT')).click().then(() => {
+            element.all(by.css('qr-code')).count().then(function(count) {
+                expect(count).toBe(1);
+            });
+            element(by.css('button.close')).click();
+        });
+    });
+
+    afterAll(function () {
+        accountMenu.click();
+        logout.click();
+    });
+});

--- a/src/test/javascript/protractor.conf.js
+++ b/src/test/javascript/protractor.conf.js
@@ -7,7 +7,8 @@ exports.config = {
     specs: [
         './e2e/account/*.spec.ts',
         './e2e/admin/*.spec.ts',
-        './e2e/entities/*.spec.ts'
+        './e2e/entities/*.spec.ts',
+        './e2e/scenarios/*.spec.ts'
     ],
 
     capabilities: {


### PR DESCRIPTION
- Fix the automated browser-based tests through protractor and adds them to Travis.
- Add a number of browser-based test scenarios.
- Add test coverage reporting to Codacy.
- Add a 'minimal' option to getting the sources for a project, this fixes an issue that caused the device type not to show up properly in the source assigner.

Closes #32 