### PR TITLE
Enable CORS for production profile as well

### DIFF
--- a/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import javax.servlet.FilterChain;
@@ -29,6 +30,11 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
             IOException, ServletException {
+        if (CorsUtils.isPreFlightRequest((HttpServletRequest) request)) {
+            log.debug("Skipping JWT check for preflight request");
+            chain.doFilter(request, response);
+            return;
+        }
         try {
             request.setAttribute(TOKEN_ATTRIBUTE, validator.validateAccessToken(getToken(request, response)));
             log.debug("Request authenticated successfully");

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -112,14 +112,6 @@ jhipster:
         hazelcast: # Hazelcast distributed cache
             time-to-live-seconds: 3600
             backup-count: 1
-    # CORS is only enabled by default with the "dev" profile, so BrowserSync can access the API
-    cors:
-        allowed-origins: "*"
-        allowed-methods: GET, PUT, POST, DELETE, OPTIONS
-        allowed-headers: "*"
-        exposed-headers:
-        allow-credentials: true
-        max-age: 1800
     metrics: # DropWizard Metrics configuration, used by MetricsConfiguration
         jmx.enabled: true
         graphite: # Use the "graphite" Maven profile to have the Graphite dependencies

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -82,13 +82,13 @@ jhipster:
         max-pool-size: 50
         queue-capacity: 10000
     # By default CORS is disabled. Uncomment to enable.
-    #cors:
-        #allowed-origins: "*"
-        #allowed-methods: GET, PUT, POST, DELETE, OPTIONS
-        #allowed-headers: "*"
+    cors:
+        allowed-origins: '*'
+        allowed-methods: GET, PUT, POST, DELETE, OPTIONS
+        allowed-headers: Authorization, Content-Type
         #exposed-headers:
-        #allow-credentials: true
-        #max-age: 1800
+        allow-credentials: true
+        max-age: 1800
     swagger:
         default-include-pattern: /api/.*
         title: ManagementPortal API


### PR DESCRIPTION
We need to enable CORS in order for browser clients that are not on the same domain to be able to make requests to MP. E.g. the aRMT app runs in a browser and needs this.