### PR TITLE
E2e stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - yarn install
 before_script:
   - cp src/test/resources/config/keystore.jks src/main/resources/config/keystore.jks # we need the keystore to run our app, and we need our app to run e2e tests
-  - ./gradlew bootRun &
+  - ./gradlew bootRun 1> /dev/null &
   - sleep 60 # give spring boot some time to start
 script:
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,9 @@ before_install:
   # Repo for Yarn
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 install:
   - yarn install
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - cp src/test/resources/config/keystore.jks src/main/resources/config/keystore.jks # we need the keystore to run our app, and we need our app to run e2e tests
   - ./gradlew bootRun &
   - sleep 60 # give spring boot some time to start

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "postcss-loader": "1.3.3",
     "protractor": "5.1.1",
     "protractor-jasmine2-screenshot-reporter": "0.3.5",
+    "jasmine-spec-reporter": "4.2.1",
     "proxy-middleware": "0.15.0",
     "rimraf": "2.6.1",
     "run-sequence": "1.2.2",

--- a/src/test/javascript/e2e/account/account.spec.ts
+++ b/src/test/javascript/e2e/account/account.spec.ts
@@ -91,6 +91,8 @@ describe('account', () => {
         password.sendKeys('newpassword');
         element(by.css('button[type=submit]')).click();
 
+        browser.waitForAngular();
+
         accountMenu.click();
         element(by.css('[routerLink="password"]')).click();
         // change back to default

--- a/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/create-and-assign-source.spec.ts
@@ -99,6 +99,7 @@ describe('Create, assign, unassign and delete source', () => {
             .all(by.xpath('ancestor::tr'))
             .all(by.cssContainingText('button', 'Delete'))
             .click().then(() => {
+                browser.waitForAngular();
                 element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
                     // if the delete succeeded the dialog will be disappeared and no Cancel button will be here anymore
                     element(by.buttonText('Cancel')).click();
@@ -111,6 +112,7 @@ describe('Create, assign, unassign and delete source', () => {
             element.all(by.cssContainingText('subjects td a', sourceName))
             .all(by.xpath('ancestor::tr'))
             .all(by.cssContainingText('button', 'Pair Sources')).first().click().then(() => {
+                browser.waitForAngular();
                 element(by.cssContainingText('button', 'Remove')).click().then(() => {
                     browser.waitForAngular();
                     // source should be moved back to available sources table
@@ -138,7 +140,9 @@ describe('Create, assign, unassign and delete source', () => {
                 .all(by.xpath('ancestor::tr'))
                 .all(by.cssContainingText('button', 'Delete'))
                 .click().then(() => {
+                    browser.waitForAngular();
                     element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
+                        browser.waitForAngular();
                         element.all(by.css('sources tbody tr')).count().then(function (count) {
                             expect(count).toBe(0);
                         });

--- a/src/test/javascript/e2e/scenarios/discontinue-subject-should-unassign-source.spec.ts
+++ b/src/test/javascript/e2e/scenarios/discontinue-subject-should-unassign-source.spec.ts
@@ -28,8 +28,8 @@ describe('Discontinued subject should unassign sources', () => {
     });
 
     it('should be able to create a subject', function () {
-        element(by.buttonText('Create a new Subject')).click().then(() => {
-            element(by.buttonText('Save')).click();
+        element(by.css('subjects h4 button.btn-primary')).click().then(() => {
+            element(by.css('.modal-footer button.btn-primary')).click();
         });
     });
 
@@ -41,7 +41,7 @@ describe('Discontinued subject should unassign sources', () => {
                 element.all(by.css('select option')).then(function(options) {
                     options[1].click();
                 });
-                element(by.cssContainingText('button.btn-primary', 'Save')).click().then(() => {
+                element(by.css('.modal-footer button.btn-primary')).click().then(() => {
                     browser.waitForAngular();
                     element.all(by.css('sources tbody tr')).count().then(function(count) {
                         expect(count).toEqual(1);
@@ -125,7 +125,8 @@ describe('Discontinued subject should unassign sources', () => {
             .all(by.xpath('ancestor::tr'))
             .all(by.cssContainingText('button', 'Delete'))
             .click().then(() => {
-                element(by.cssContainingText('.modal-footer button', 'Delete')).click().then(() => {
+                element(by.css('.modal-footer button.btn-danger')).click().then(() => {
+                    browser.waitForAngular();
                     element.all(by.css('sources tbody tr')).count().then(function (count) {
                         expect(count).toBe(0);
                     });
@@ -140,7 +141,7 @@ describe('Discontinued subject should unassign sources', () => {
                 .element(by.xpath('ancestor::tr'));
             row.element(by.buttonText('Delete')).click().then(() => {
                 expect(element(by.css('h4.modal-title')).getAttribute('jhitranslate')).toMatch('entity.delete.title');
-                element(by.name('deleteForm')).element(by.buttonText('Delete')).click();
+                element(by.css('.modal-footer button.btn-danger')).click();
             });
         });
     });

--- a/src/test/javascript/protractor.conf.js
+++ b/src/test/javascript/protractor.conf.js
@@ -3,7 +3,7 @@ const JasmineReporters = require('jasmine-reporters');
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
-    allScriptsTimeout: 20000,
+    allScriptsTimeout: 120000,
 
     specs: [
         './e2e/account/*.spec.ts',
@@ -17,7 +17,7 @@ exports.config = {
         'phantomjs.binary.path': require('phantomjs-prebuilt').path,
         'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG'],
         chromeOptions: {
-            args: [ "--headless", "--disable-gpu", "--window-size=800x600" ]
+            args: [ "--headless", "--disable-gpu", "--window-size=1280x1024" ]
         }
     },
 

--- a/src/test/javascript/protractor.conf.js
+++ b/src/test/javascript/protractor.conf.js
@@ -1,5 +1,6 @@
 const HtmlScreenshotReporter = require("protractor-jasmine2-screenshot-reporter");
 const JasmineReporters = require('jasmine-reporters');
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
     allScriptsTimeout: 20000,
@@ -14,7 +15,10 @@ exports.config = {
     capabilities: {
         'browserName': 'chrome',
         'phantomjs.binary.path': require('phantomjs-prebuilt').path,
-        'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
+        'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG'],
+        chromeOptions: {
+            args: [ "--headless", "--disable-gpu", "--window-size=800x600" ]
+        }
     },
 
     directConnect: true,
@@ -25,7 +29,8 @@ exports.config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 60000
+        defaultTimeoutInterval: 60000,
+        print: function() {}
     },
 
     beforeLaunch: function() {
@@ -42,6 +47,11 @@ exports.config = {
         }));
         jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
             dest: "build/reports/e2e/screenshots"
+        }));
+        jasmine.getEnv().addReporter(new SpecReporter({
+            spec: {
+                displayStacktrace: true
+            }
         }));
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,7 +1207,7 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@^1.1.0, colors@^1.1.2, colors@~1.1.2:
+colors@1.1.2, colors@^1.1.0, colors@^1.1.2, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -3817,6 +3817,12 @@ jasmine-reporters@2.2.1:
   dependencies:
     mkdirp "^0.5.1"
     xmldom "^0.1.22"
+
+jasmine-spec-reporter@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz#1d632aec0341670ad324f92ba84b4b32b35e9e22"
+  dependencies:
+    colors "1.1.2"
 
 jasmine@^2.5.3:
   version "2.6.0"


### PR DESCRIPTION
Another attempt at making the e2e tests stable in Travis. Changes are:
- Use Chrome's native headless mode instead of Xvfb to make test results consistent between running locally and in CI
- Don't show `stdout` of running MP instance during e2e tests in Travis to clean up output
- Use a custom protractor reporter to show more clearly the test results
- Modifications to tests to have the browser wait for angular more.
