### PR TITLE
Disable compression in prod profile

### DIFF
--- a/src/main/java/org/radarcns/management/filters/OAuth2TokenRequestPostZuulFilter.java
+++ b/src/main/java/org/radarcns/management/filters/OAuth2TokenRequestPostZuulFilter.java
@@ -47,8 +47,8 @@ public class OAuth2TokenRequestPostZuulFilter extends ZuulFilter {
         final String requestURI = ctx.getRequest().getRequestURI();
         final String requestMethod = ctx.getRequest().getMethod();
         Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
-        try {
-            final InputStream is = ctx.getResponseDataStream();
+
+        try (final InputStream is = ctx.getResponseDataStream()) {
             String responseBody = IOUtils.toString(is, "UTF-8");
             if (responseBody.contains("refresh_token")) {
                 final Map<String, Object> responseMap = mapper

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -101,8 +101,7 @@ managementportal:
     frontend:
         clientId: ManagementPortalapp
         clientSecret:
-        clientScopes: read,write
-        sesssionTimeout : 86400
+        sessionTimeout : 86400 # not supported yet
 
 # ===================================================================
 # JHipster specific properties

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -83,10 +83,6 @@ liquibase:
 # ===================================================================
 server:
     port: 8080
-    compression:
-        enabled: true
-        mime-types: text/html,text/xml,text/plain,text/css, application/javascript, application/json
-        min-response-size: 1024
     contextPath: /managementportal
 
 


### PR DESCRIPTION
Due to some confusion with Zuul filter/proxy and compression the responses are getting messed up in production profile. Thus disabling compression for prod profile temporarily.
