### PR TITLE
Uriencode frontend requests

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/config/Constants.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/config/Constants.java
@@ -1,4 +1,4 @@
-package org.radarcns.management.config;
+package org.radarcns.auth.config;
 
 /**
  * Application constants.

--- a/radar-auth/src/main/java/org/radarcns/auth/config/Constants.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/config/Constants.java
@@ -6,7 +6,7 @@ package org.radarcns.auth.config;
 public final class Constants {
 
     //Regex for acceptable logins
-    public static final String LOGIN_REGEX = "^[_'.@A-Za-z0-9-]*$";
+    public static final String ENTITY_ID_REGEX = "^[_'.@A-Za-z0-9-]*$";
 
     public static final String SYSTEM_ACCOUNT = "system";
     public static final String ANONYMOUS_USER = "anonymoususer";

--- a/src/main/java/org/radarcns/management/domain/Authority.java
+++ b/src/main/java/org/radarcns/management/domain/Authority.java
@@ -6,9 +6,11 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.radarcns.auth.config.Constants;
 
 /**
  * An authority (a security role) used by Spring Security.
@@ -23,6 +25,7 @@ public class Authority implements Serializable {
     @NotNull
     @Size(min = 0, max = 50)
     @Id
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(length = 50)
     private String name;
 

--- a/src/main/java/org/radarcns/management/domain/Project.java
+++ b/src/main/java/org/radarcns/management/domain/Project.java
@@ -11,9 +11,12 @@ import java.util.Set;
 import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Cascade;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.enumeration.ProjectStatus;
 
 /**
@@ -32,6 +35,7 @@ public class Project extends AbstractAuditingEntity implements Serializable {
     private Long id;
 
     @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "project_name", nullable = false , unique = true)
     private String projectName;
 

--- a/src/main/java/org/radarcns/management/domain/Source.java
+++ b/src/main/java/org/radarcns/management/domain/Source.java
@@ -3,6 +3,7 @@ package org.radarcns.management.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.radarcns.auth.config.Constants;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -20,6 +21,7 @@ import javax.persistence.PrePersist;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,9 +50,11 @@ public class Source extends AbstractAuditingEntity implements Serializable {
     private UUID sourceId;
 
     @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "source_name", nullable = false, unique = true)
     private String sourceName;
 
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "expected_source_name")
     private String expectedSourceName;
 

--- a/src/main/java/org/radarcns/management/domain/Source.java
+++ b/src/main/java/org/radarcns/management/domain/Source.java
@@ -54,7 +54,6 @@ public class Source extends AbstractAuditingEntity implements Serializable {
     @Column(name = "source_name", nullable = false, unique = true)
     private String sourceName;
 
-    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "expected_source_name")
     private String expectedSourceName;
 

--- a/src/main/java/org/radarcns/management/domain/SourceData.java
+++ b/src/main/java/org/radarcns/management/domain/SourceData.java
@@ -14,10 +14,13 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.enumeration.ProcessingState;
 
 /**
@@ -42,6 +45,7 @@ public class SourceData extends AbstractAuditingEntity implements Serializable {
 
     // this will be the unique human readable identifier of
     @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "source_data_name", nullable = false, unique = true)
     private String sourceDataName;
 

--- a/src/main/java/org/radarcns/management/domain/SourceType.java
+++ b/src/main/java/org/radarcns/management/domain/SourceType.java
@@ -18,10 +18,13 @@ import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.enumeration.SourceTypeScope;
 
 /**
@@ -39,6 +42,8 @@ public class SourceType extends AbstractAuditingEntity implements Serializable {
     @SequenceGenerator(name = "sequenceGenerator", initialValue = 1000)
     private Long id;
 
+    @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "producer")
     private String producer;
 
@@ -55,10 +60,12 @@ public class SourceType extends AbstractAuditingEntity implements Serializable {
     private String appProvider;
 
     @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "model", nullable = false )
     private String model;
 
     @NotNull
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Column(name = "catalog_version", nullable = false)
     private String catalogVersion;
 

--- a/src/main/java/org/radarcns/management/domain/User.java
+++ b/src/main/java/org/radarcns/management/domain/User.java
@@ -45,7 +45,7 @@ public class User extends AbstractAuditingEntity implements Serializable {
     private Long id;
 
     @NotNull
-    @Pattern(regexp = Constants.LOGIN_REGEX)
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Size(min = 1, max = 50)
     @Column(length = 50, unique = true, nullable = false)
     private String login;

--- a/src/main/java/org/radarcns/management/domain/User.java
+++ b/src/main/java/org/radarcns/management/domain/User.java
@@ -16,7 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
@@ -28,7 +27,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.validator.constraints.Email;
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 
 /**
  * A user.

--- a/src/main/java/org/radarcns/management/repository/CustomAuditEventRepository.java
+++ b/src/main/java/org/radarcns/management/repository/CustomAuditEventRepository.java
@@ -1,6 +1,6 @@
 package org.radarcns.management.repository;
 
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.config.audit.AuditEventConverter;
 import org.radarcns.management.domain.PersistentAuditEvent;
 

--- a/src/main/java/org/radarcns/management/security/SpringSecurityAuditorAware.java
+++ b/src/main/java/org/radarcns/management/security/SpringSecurityAuditorAware.java
@@ -1,6 +1,6 @@
 package org.radarcns.management.security;
 
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -1,7 +1,7 @@
 package org.radarcns.management.service;
 
 import org.radarcns.auth.authorization.AuthoritiesConstants;
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.User;

--- a/src/main/java/org/radarcns/management/service/dto/UserDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/UserDTO.java
@@ -14,7 +14,7 @@ public class UserDTO {
 
     private Long id;
 
-    @Pattern(regexp = Constants.LOGIN_REGEX)
+    @Pattern(regexp = Constants.ENTITY_ID_REGEX)
     @Size(min = 1, max = 50)
     private String login;
 

--- a/src/main/java/org/radarcns/management/service/dto/UserDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/UserDTO.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import org.hibernate.validator.constraints.Email;
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 
 /**
  * A DTO representing a user, with his authorities.

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -1,6 +1,7 @@
 package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.SubjectRepository;
@@ -123,7 +124,7 @@ public class OAuthClientsResource {
      * @param id the client id for which to fetch the details
      * @return the client as a {@link ClientDetailsDTO}
      */
-    @GetMapping("/oauth-clients/{id}")
+    @GetMapping("/oauth-clients/{id:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<ClientDetailsDTO> getOAuthClientById(@PathVariable("id") String id) {
         checkPermission(getJWT(servletRequest), OAUTHCLIENTS_READ);
@@ -174,7 +175,7 @@ public class OAuthClientsResource {
      * @param id The id of the client to delete
      * @return a ResponseEntity indicating success or failure
      */
-    @DeleteMapping("/oauth-clients/{id}")
+    @DeleteMapping("/oauth-clients/{id:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteOAuthClient(@PathVariable String id) {
         checkPermission(getJWT(servletRequest), OAUTHCLIENTS_DELETE);

--- a/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.authorization.Permission;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.repository.SubjectRepository;
@@ -151,7 +152,7 @@ public class ProjectResource {
      * @param projectName the projectName of the projectDTO to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the projectDTO, or with status 404 (Not Found)
      */
-    @GetMapping("/projects/{projectName}")
+    @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<ProjectDTO> getProject(@PathVariable String projectName) {
         log.debug("REST request to get Project : {}", projectName);
@@ -168,7 +169,7 @@ public class ProjectResource {
      * @param projectName the projectName of the projectDTO to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the projectDTO, or with status 404 (Not Found)
      */
-    @GetMapping("/projects/{projectName}/source-types")
+    @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}/source-types")
     @Timed
     public List<SourceTypeDTO> getSourceTypesOfProject(@PathVariable String projectName) {
         log.debug("REST request to get Project : {}", projectName);
@@ -186,7 +187,7 @@ public class ProjectResource {
      * @param projectName the projectName of the projectDTO to delete
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/projects/{projectName}")
+    @DeleteMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteProject(@PathVariable String projectName) {
         log.debug("REST request to delete Project : {}", projectName);
@@ -203,7 +204,7 @@ public class ProjectResource {
      *
      * @return the ResponseEntity with status 200 (OK) and the list of roles in body
      */
-    @GetMapping("/projects/{projectName}/roles")
+    @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}/roles")
     @Timed
     public List<RoleDTO> getRolesByProject(@PathVariable String projectName) {
         log.debug("REST request to get all Roles for project {}", projectName);
@@ -219,7 +220,7 @@ public class ProjectResource {
      *
      * @return the ResponseEntity with status 200 (OK) and the list of sources in body
      */
-    @GetMapping("/projects/{projectName}/sources")
+    @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}/sources")
     @Timed
     public ResponseEntity getAllSourcesForProject(@PathVariable String projectName,
             @RequestParam(value = "assigned", required = false) Boolean assigned,
@@ -252,7 +253,7 @@ public class ProjectResource {
         }
     }
 
-    @GetMapping("/projects/{projectName}/subjects")
+    @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}/subjects")
     @Timed
     public ResponseEntity<List<SubjectDTO>> getAllSubjects(@PathVariable String projectName) {
         checkPermissionOnProject(SecurityUtils.getJWT(servletRequest), Permission.SUBJECT_READ,

--- a/src/main/java/org/radarcns/management/web/rest/RoleResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/RoleResource.java
@@ -3,6 +3,7 @@ package org.radarcns.management.web.rest;
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.service.RoleService;
 import org.radarcns.management.service.dto.RoleDTO;
 import org.radarcns.management.web.rest.util.HeaderUtil;
@@ -125,7 +126,7 @@ public class RoleResource {
      * @param authorityName The authority name
      * @return the ResponseEntity with status 200 (OK) and with body the roleDTO, or with status 404 (Not Found)
      */
-    @GetMapping("/roles/{projectName}/{authorityName}")
+    @GetMapping("/roles/{projectName:" + Constants.ENTITY_ID_REGEX + "}/{authorityName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<RoleDTO> getRole(@PathVariable String projectName,
         @PathVariable String authorityName) {

--- a/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceDataResource.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.service.SourceDataService;
 import org.radarcns.management.service.dto.SourceDataDTO;
 import org.radarcns.management.web.rest.util.HeaderUtil;
@@ -116,7 +118,7 @@ public class SourceDataResource {
      * @param sourceDataName the sourceDataName of the sourceDataDTO to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the sourceDataDTO, or with status 404 (Not Found)
      */
-    @GetMapping("/source-data/{sourceDataName}")
+    @GetMapping("/source-data/{sourceDataName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<SourceDataDTO> getSourceData(@PathVariable String sourceDataName) {
         checkPermission(getJWT(servletRequest), SOURCEDATA_READ);
@@ -129,7 +131,7 @@ public class SourceDataResource {
      * @param sourceDataName the sourceDataName of the sourceDataDTO to delete
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/source-data/{sourceDataName}")
+    @DeleteMapping("/source-data/{sourceDataName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteSourceData(@PathVariable String sourceDataName) {
         checkPermission(getJWT(servletRequest), SOURCEDATA_DELETE);

--- a/src/main/java/org/radarcns/management/web/rest/SourceResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceResource.java
@@ -3,6 +3,7 @@ package org.radarcns.management.web.rest;
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.repository.SourceRepository;
 import org.radarcns.management.service.SourceTypeService;
 import org.radarcns.management.service.ProjectService;
@@ -145,7 +146,7 @@ public class SourceResource {
      * @param sourceName the name of the sourceDTO to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the sourceDTO, or with status 404 (Not Found)
      */
-    @GetMapping("/sources/{sourceName}")
+    @GetMapping("/sources/{sourceName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<SourceDTO> getSource(@PathVariable String sourceName) {
         log.debug("REST request to get Source : {}", sourceName);
@@ -159,7 +160,7 @@ public class SourceResource {
      * @param sourceName the id of the sourceDTO to delete
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/sources/{sourceName}")
+    @DeleteMapping("/sources/{sourceName:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteSource(@PathVariable String sourceName) {
         log.debug("REST request to delete Source : {}", sourceName);

--- a/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceTypeResource.java
@@ -2,6 +2,7 @@ package org.radarcns.management.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.repository.SourceTypeRepository;
 import org.radarcns.management.service.SourceTypeService;
@@ -129,7 +130,7 @@ public class SourceTypeResource {
      * @param producer The producer
      * @return A list of objects matching the producer
      */
-    @GetMapping("/source-types/{producer}")
+    @GetMapping("/source-types/{producer:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<List<SourceTypeDTO>> getSourceTypes(@PathVariable String producer) {
         checkPermission(getJWT(servletRequest), SOURCETYPE_READ);
@@ -144,7 +145,8 @@ public class SourceTypeResource {
      * @param model The model
      * @return A list of objects matching the producer and model
      */
-    @GetMapping("/source-types/{producer}/{model}")
+    @GetMapping("/source-types/{producer:" + Constants.ENTITY_ID_REGEX + "}/{model:"
+            + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<List<SourceTypeDTO>> getSourceTypes(@PathVariable String producer,
             @PathVariable String model) {
@@ -160,7 +162,8 @@ public class SourceTypeResource {
      * @param version The version
      * @return A single SourceType object matching the producer, model and version
      */
-    @GetMapping("/source-types/{producer}/{model}/{version}")
+    @GetMapping("/source-types/{producer:" + Constants.ENTITY_ID_REGEX + "}/{model:"
+            + Constants.ENTITY_ID_REGEX + "}/{version:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<SourceTypeDTO> getSourceTypes(@PathVariable String producer,
         @PathVariable String model, @PathVariable String version) {
@@ -178,7 +181,8 @@ public class SourceTypeResource {
      * @param version The version
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/source-types/{producer}/{model}/{version}")
+    @DeleteMapping("/source-types/{producer:" + Constants.ENTITY_ID_REGEX + "}/{model:"
+            + Constants.ENTITY_ID_REGEX + "}/{version:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteSourceType(@PathVariable String producer,
         @PathVariable String model, @PathVariable String version) {

--- a/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.authorization.Permission;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.Subject;
@@ -241,7 +242,7 @@ public class SubjectResource {
      * @return the ResponseEntity with status 200 (OK) and with body the subjectDTO, or with status
      * 404 (Not Found)
      */
-    @GetMapping("/subjects/{login}")
+    @GetMapping("/subjects/{login:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<SubjectDTO> getSubject(@PathVariable String login) {
         log.debug("REST request to get Subject : {}", login);
@@ -261,7 +262,7 @@ public class SubjectResource {
      * @param login the login of the subjectDTO to delete
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/subjects/{login}")
+    @DeleteMapping("/subjects/{login:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteSubject(@PathVariable String login) {
         log.debug("REST request to delete Subject : {}", login);
@@ -294,7 +295,7 @@ public class SubjectResource {
      * @return The {@link MinimalSourceDetailsDTO} completed with all identifying fields.
      *
      */
-    @PostMapping("/subjects/{login}/sources")
+    @PostMapping("/subjects/{login:" + Constants.ENTITY_ID_REGEX + "}/sources")
     @ApiResponses({
             @ApiResponse(code = 200, message = "An existing source was assigned"),
             @ApiResponse(code = 201, message = "A new source was created and assigned"),
@@ -386,7 +387,7 @@ public class SubjectResource {
         }
     }
 
-    @GetMapping("/subjects/{login}/sources")
+    @GetMapping("/subjects/{login:" + Constants.ENTITY_ID_REGEX + "}/sources")
     @Timed
     public ResponseEntity<List<MinimalSourceDetailsDTO>> getSubjectSources(
         @PathVariable String login) {

--- a/src/main/java/org/radarcns/management/web/rest/UserResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/UserResource.java
@@ -212,7 +212,7 @@ public class UserResource {
      * @param login the login of the user to find
      * @return the ResponseEntity with status 200 (OK) and with body the "login" user, or with status 404 (Not Found)
      */
-    @GetMapping("/users/{login:" + Constants.LOGIN_REGEX + "}")
+    @GetMapping("/users/{login:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<UserDTO> getUser(@PathVariable String login) {
         log.debug("REST request to get User : {}", login);
@@ -226,7 +226,7 @@ public class UserResource {
      * @param login
      * @return
      */
-    @GetMapping("/users/{login:" + Constants.LOGIN_REGEX + "}/projects")
+    @GetMapping("/users/{login:" + Constants.ENTITY_ID_REGEX + "}/projects")
     @Timed
     public List<ProjectDTO> getUserProjects(@PathVariable String login) {
         log.debug("REST request to get User's project : {}", login);
@@ -240,7 +240,7 @@ public class UserResource {
      * @param login the login of the user to delete
      * @return the ResponseEntity with status 200 (OK)
      */
-    @DeleteMapping("/users/{login:" + Constants.LOGIN_REGEX + "}")
+    @DeleteMapping("/users/{login:" + Constants.ENTITY_ID_REGEX + "}")
     @Timed
     public ResponseEntity<Void> deleteUser(@PathVariable String login) {
         log.debug("REST request to delete User: {}", login);

--- a/src/main/java/org/radarcns/management/web/rest/UserResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/UserResource.java
@@ -3,7 +3,7 @@ package org.radarcns.management.web.rest;
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
 import io.swagger.annotations.ApiParam;
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.SubjectRepository;

--- a/src/main/java/org/radarcns/management/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/org/radarcns/management/web/rest/errors/ExceptionTranslator.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -35,6 +35,17 @@ public class ExceptionTranslator {
     @ResponseBody
     public ErrorVM processConcurrencyError(ConcurrencyFailureException ex) {
         return new ErrorVM(ErrorConstants.ERR_CONCURRENCY_FAILURE);
+    }
+
+    @ExceptionHandler(TransactionSystemException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorVM processValidationError(TransactionSystemException ex) {
+        // TODO: this is the top level exception that is thrown when e.g. a
+        // ConstraintValidationException occurs. Need to investigate what other exceptions result
+        // in this one and probably add a check for it.
+        ErrorVM dto = new ErrorVM(ErrorConstants.ERR_VALIDATION, ex.getMessage());
+        return dto;
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -98,13 +109,6 @@ public class ExceptionTranslator {
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     public ErrorVM processMethodNotSupportedException(HttpRequestMethodNotSupportedException exception) {
         return new ErrorVM(ErrorConstants.ERR_METHOD_NOT_SUPPORTED, exception.getMessage());
-    }
-
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    @ResponseBody
-    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
-    public ErrorVM processMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException ex) {
-        return new ErrorVM(ErrorConstants.ERR_MEDIA_TYPE_NOT_SUPPORTED, ex.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client-dialog.component.html
@@ -13,7 +13,17 @@
         <div class="form-group">
             <label class="form-control-label" for="id" jhiTranslate="managementPortalApp.oauthClient.clientId">Client ID</label>
             <input *ngIf="!newClient" type="text" class="form-control" id="id" name="id" [(ngModel)]="client.clientId" readonly />
-            <input *ngIf="newClient" type="text" class="form-control" id="id" name="id" [(ngModel)]="client.clientId" required />
+            <input *ngIf="newClient" type="text" class="form-control" id="id" name="id" [(ngModel)]="client.clientId" required pattern="[_'.@A-Za-z0-9-]*" />
+            <div [hidden]="!(editForm.controls.id?.dirty && editForm.controls.id?.invalid)">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.id?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.id?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
+                </small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="secret" jhiTranslate="managementPortalApp.oauthClient.clientSecret">Client Secret</label>
@@ -21,17 +31,35 @@
                 <input type="text" class="form-control" id="secret" name="clientSecret" [(ngModel)]="client.clientSecret" [disabled]="protectedClient" [required]="newClient" />
                 <span class="input-group-btn"><button class="btn btn-secondary" type="button" (click)="generateRandomSecret()"><span class="fa fa-magic">&nbsp;</span>Randomize</button></span>
             </div>
+            <div [hidden]="!newClient || (newClient && !(editForm.controls.clientSecret?.dirty && editForm.controls.clientSecret?.invalid))">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.clientSecret?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+            </div>
             <small id="secretHelp" class="form-text text-muted" *ngIf="!newClient">If this field is left empty the secret will not be modified.</small>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="scope" jhiTranslate="managementPortalApp.oauthClient.scope">Scope</label>
             <input type="text" class="form-control" id="scope" name="scope" [(ngModel)]="scopeList" [disabled]="protectedClient" required />
             <small id="scopeHelp" class="form-text text-muted">Comma seperated list of scopes. Scopes should have the following structure: ENTITY.OPERATION. See the <a href="https://github.com/RADAR-CNS/ManagementPortal/tree/master/radar-auth">radar-auth library documentation</a> for more information.</small>
+            <div [hidden]="!(editForm.controls.scope?.dirty && editForm.controls.scope?.invalid)">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.scope?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="resourceIds" jhiTranslate="managementPortalApp.oauthClient.resourceIds">Resources</label>
             <input type="text" class="form-control" id="resourceIds" name="resourceIds" [(ngModel)]="resourcesList" [disabled]="protectedClient" required />
             <small id="resourceIdsHelp" class="form-text text-muted">Comma seperated list of allowed resource IDs.</small>
+            <div [hidden]="!(editForm.controls.resourceIds?.dirty && editForm.controls.resourceIds?.invalid)">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.resourceIds?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="grantTypes" jhiTranslate="managementPortalApp.oauthClient.authorizedGrantTypes">Grant Types</label>
@@ -51,10 +79,30 @@
         <div class="form-group">
             <label class="form-control-label" for="accessTokenValidity" jhiTranslate="managementPortalApp.oauthClient.accessTokenValidity">Access Token Validity</label>
             <input type="text" class="form-control" id="accessTokenValidity" name="accessTokenValidity" [(ngModel)]="client.accessTokenValiditySeconds" [disabled]="protectedClient" required pattern="\d+" />
+            <div [hidden]="!(editForm.controls.accessTokenValidity?.dirty && editForm.controls.accessTokenValidity?.invalid)">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.accessTokenValidity?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.accessTokenValidity?.errors?.pattern" jhiTranslate="entity.validation.number">
+                    This field is numeric.
+                </small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="refreshTokenValidity" jhiTranslate="managementPortalApp.oauthClient.refreshTokenValidity">Refresh Token Validity</label>
             <input type="text" class="form-control" id="refreshTokenValidity" name="refreshTokenValidity" [(ngModel)]="client.refreshTokenValiditySeconds" [disabled]="protectedClient" required pattern="\d+" />
+            <div [hidden]="!(editForm.controls.refreshTokenValidity?.dirty && editForm.controls.refreshTokenValidity?.invalid)">
+                <small class="form-text text-danger"
+                       [hidden]="!editForm.controls.refreshTokenValidity?.errors?.required" jhiTranslate="entity.validation.required">
+                    This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.refreshTokenValidity?.errors?.pattern" jhiTranslate="entity.validation.number">
+                    This field is numeric.
+                </small>
+            </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" for="dynamicRegistration" jhiTranslate="managementPortalApp.oauthClient.additionalInformation">Additional Information</label>

--- a/src/main/webapp/app/entities/oauth-client/oauth-client.service.ts
+++ b/src/main/webapp/app/entities/oauth-client/oauth-client.service.ts
@@ -25,7 +25,7 @@ constructor(private http: Http) { }
     }
 
     find(id: string): Observable<OAuthClient> {
-        return this.http.get(`${this.resourceUrl}/${id}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(id)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -37,7 +37,7 @@ constructor(private http: Http) { }
     }
 
     delete(id: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${id}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(id)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/entities/project/project-dialog.component.html
+++ b/src/main/webapp/app/entities/project/project-dialog.component.html
@@ -15,12 +15,15 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.project.projectName" for="field_projectName">Project Name</label>
             <input type="text" class="form-control" name="projectName" id="field_projectName"
-                [(ngModel)]="project.projectName"
-            required />
+                [(ngModel)]="project.projectName" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.projectName?.dirty && editForm.controls.projectName?.invalid)">
                 <small class="form-text text-danger"
                    [hidden]="!editForm.controls.projectName?.errors?.required" jhiTranslate="entity.validation.required">
                    This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.projectName?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>

--- a/src/main/webapp/app/entities/project/project.service.ts
+++ b/src/main/webapp/app/entities/project/project.service.ts
@@ -32,7 +32,7 @@ export class ProjectService {
     }
 
     find(projectName: string): Observable<Project> {
-        return this.http.get(`${this.resourceUrl}/${projectName}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(projectName)}`).map((res: Response) => {
             const jsonResponse = res.json();
             jsonResponse.startDate = this.dateUtils
                 .convertDateTimeFromServer(jsonResponse.startDate);
@@ -61,7 +61,7 @@ export class ProjectService {
     }
 
     delete(projectName: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${projectName}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(projectName)}`);
     }
 
     private convertResponse(res: any): any {

--- a/src/main/webapp/app/entities/role/role.service.ts
+++ b/src/main/webapp/app/entities/role/role.service.ts
@@ -25,7 +25,7 @@ export class RoleService {
     }
 
     find(projectName: string, authorityName: string): Observable<Role> {
-        return this.http.get(`${this.resourceUrl}/${projectName}/${authorityName}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(projectName)}/${encodeURIComponent(authorityName)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -41,7 +41,7 @@ export class RoleService {
     }
 
     delete(projectName: string, authorityName: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${projectName}/${authorityName}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(projectName)}/${encodeURIComponent(authorityName)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/entities/source-data/source-data-dialog.component.html
+++ b/src/main/webapp/app/entities/source-data/source-data-dialog.component.html
@@ -34,12 +34,15 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.sourceData.sourceDataName" for="field_sourceDataName">Source Data Name</label>
             <input type="text" class="form-control" name="sourceDataName" id="field_sourceDataName"
-                   [(ngModel)]="sourceData.sourceDataName"
-                   required />
+                   [(ngModel)]="sourceData.sourceDataName" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.sourceDataName?.dirty && editForm.controls.sourceDataName?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.sourceDataName?.errors?.required" jhiTranslate="entity.validation.required">
                     This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.sourceDataName?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>

--- a/src/main/webapp/app/entities/source-data/source-data.service.ts
+++ b/src/main/webapp/app/entities/source-data/source-data.service.ts
@@ -25,7 +25,7 @@ export class SourceDataService {
     }
 
     find(sourceDataName: string): Observable<SourceData> {
-        return this.http.get(`${this.resourceUrl}/${sourceDataName}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(sourceDataName)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -37,7 +37,7 @@ export class SourceDataService {
     }
 
     delete(sourceDataName: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${sourceDataName}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(sourceDataName)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/entities/source-type/source-type-dialog.component.html
+++ b/src/main/webapp/app/entities/source-type/source-type-dialog.component.html
@@ -15,36 +15,45 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.sourceType.producer" for="field_producer">Producer</label>
             <input type="text" class="form-control" name="producer" id="field_producer"
-                [(ngModel)]="sourceType.producer"
-             required />
+                [(ngModel)]="sourceType.producer" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.producer?.dirty && editForm.controls.producer?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.producer?.errors?.required" jhiTranslate="entity.validation.required">
                     This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.producer?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.sourceType.model" for="field_model">Model</label>
             <input type="text" class="form-control" name="model" id="field_model"
-                [(ngModel)]="sourceType.model"
-            required />
+                [(ngModel)]="sourceType.model" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.model?.dirty && editForm.controls.model?.invalid)">
                 <small class="form-text text-danger"
                    [hidden]="!editForm.controls.model?.errors?.required" jhiTranslate="entity.validation.required">
                    This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.model?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.sourceType.catalogVersion" for="field_catalogVersion">Device Version</label>
             <input type="text" class="form-control" name="catalogVersion" id="field_catalogVersion"
-                   [(ngModel)]="sourceType.catalogVersion"
-                   required />
+                   [(ngModel)]="sourceType.catalogVersion" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.catalogVersion?.dirty && editForm.controls.catalogVersion?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.catalogVersion?.errors?.required" jhiTranslate="entity.validation.required">
                     This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.catalogVersion?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>

--- a/src/main/webapp/app/entities/source-type/source-type.service.ts
+++ b/src/main/webapp/app/entities/source-type/source-type.service.ts
@@ -25,7 +25,7 @@ export class SourceTypeService {
     }
 
     find(producer: string, model: string, version: string): Observable<SourceType> {
-        return this.http.get(`${this.resourceUrl}/${producer}/${model}/${version}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(producer)}/${encodeURIComponent(model)}/${encodeURIComponent(version)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -37,7 +37,7 @@ export class SourceTypeService {
     }
 
     delete(producer: string, model: string, version: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${producer}/${model}/${version}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(producer)}/${encodeURIComponent(model)}/${encodeURIComponent(version)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/entities/source/general-source-dialog.component.html
+++ b/src/main/webapp/app/entities/source/general-source-dialog.component.html
@@ -20,12 +20,15 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="managementPortalApp.source.sourceName" for="field_sourceName">Source Name</label>
             <input type="text" class="form-control" name="sourceName" id="field_sourceName"
-                   [(ngModel)]="source.sourceName"
-                   required />
+                   [(ngModel)]="source.sourceName" required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.sourceName?.dirty && editForm.controls.sourceName?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.sourceName?.errors?.required" jhiTranslate="entity.validation.required">
                     This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.sourceName?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>

--- a/src/main/webapp/app/shared/source/source-dialog.component.html
+++ b/src/main/webapp/app/shared/source/source-dialog.component.html
@@ -16,11 +16,15 @@
             <label class="form-control-label" jhiTranslate="managementPortalApp.source.sourceName" for="field_sourceName">Source Name</label>
             <input type="text" class="form-control" name="sourceName" id="field_sourceName"
                    [(ngModel)]="source.sourceName"
-                   required />
+                   required pattern="[_'.@A-Za-z0-9-]*" />
             <div [hidden]="!(editForm.controls.sourceName?.dirty && editForm.controls.sourceName?.invalid)">
                 <small class="form-text text-danger"
                        [hidden]="!editForm.controls.sourceName?.errors?.required" jhiTranslate="entity.validation.required">
                     This field is required.
+                </small>
+                <small class="form-text text-danger"
+                        [hidden]="!editForm.controls.sourceName?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{pattern: 'alphanumerics, dash (-), underscore (_) and period (.)'}">
+                    Validation error.
                 </small>
             </div>
         </div>

--- a/src/main/webapp/app/shared/source/source.service.ts
+++ b/src/main/webapp/app/shared/source/source.service.ts
@@ -27,7 +27,7 @@ export class SourceService {
     }
 
     find(name: string): Observable<Source> {
-        return this.http.get(`${this.resourceUrl}/${name}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(name)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -39,7 +39,7 @@ export class SourceService {
     }
 
     delete(sourceName: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${sourceName}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(sourceName)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/shared/subject/subject.service.ts
+++ b/src/main/webapp/app/shared/subject/subject.service.ts
@@ -33,7 +33,7 @@ export class SubjectService {
     }
 
     find(login: string): Observable<Subject> {
-        return this.http.get(`${this.resourceUrl}/${login}`).map((res: Response) => {
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(login)}`).map((res: Response) => {
             return res.json();
         });
     }
@@ -45,7 +45,7 @@ export class SubjectService {
     }
 
     delete(login: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${login}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(login)}`);
     }
     private createRequestOption(req?: any): BaseRequestOptions {
         const options: BaseRequestOptions = new BaseRequestOptions();

--- a/src/main/webapp/app/shared/user/user.service.ts
+++ b/src/main/webapp/app/shared/user/user.service.ts
@@ -19,11 +19,11 @@ export class UserService {
     }
 
     find(login: string): Observable<User> {
-        return this.http.get(`${this.resourceUrl}/${login}`).map((res: Response) => res.json());
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(login)}`).map((res: Response) => res.json());
     }
 
     findProject(login: string): Observable<Response> {
-        return this.http.get(`${this.resourceUrl}/${login}/projects`);
+        return this.http.get(`${this.resourceUrl}/${encodeURIComponent(login)}/projects`);
     }
 
     query(req?: any): Observable<Response> {
@@ -44,7 +44,7 @@ export class UserService {
     }
 
     delete(login: string): Observable<Response> {
-        return this.http.delete(`${this.resourceUrl}/${login}`);
+        return this.http.delete(`${this.resourceUrl}/${encodeURIComponent(login)}`);
     }
 
     findByProjectAndAuthority(req: any) : Observable<Response> {

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -131,7 +131,7 @@
             "max": "This field cannot be more than {{ max }}.",
             "minbytes": "This field should be at least {{ min }} bytes.",
             "maxbytes": "This field cannot be more than {{ max }} bytes.",
-            "pattern": "This field should follow pattern for {{ pattern }}.",
+            "pattern": "This field only allows the following characters: {{ pattern }}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."
         }

--- a/src/main/webapp/i18n/en/oauthClient.json
+++ b/src/main/webapp/i18n/en/oauthClient.json
@@ -20,7 +20,10 @@
             "refreshTokenValidity": "Refresh Token Validity",
             "authorities": "Authorities",
             "additionalInformation": "Additional Information",
-            "actions": "Actions"
+            "actions": "Actions",
+            "error": {
+                "validation": "Validation error, check the entered values in the fields."
+            }
         }
     }
 }

--- a/src/main/webapp/i18n/en/source.json
+++ b/src/main/webapp/i18n/en/source.json
@@ -26,7 +26,8 @@
         }
     },
     "error": {
-        "sourceNameExists": " Source Name is already registered",
-        "sourceIsAssigned": "Cannot edit/delete a currently assigned source."
+        "sourceNameExists": "Source Name is already registered.",
+        "sourceIsAssigned": "Cannot edit/delete a currently assigned source.",
+        "validation": "Validation error, check the entered values in the fields."
     }
 }

--- a/src/main/webapp/i18n/en/sourceData.json
+++ b/src/main/webapp/i18n/en/sourceData.json
@@ -24,6 +24,7 @@
         }
     },
     "error" : {
-        "sourceDataNameAvailable" : "SourceDataName is already in use"
+        "sourceDataNameAvailable" : "SourceDataName is already in use",
+        "validation": "Validation error, check the entered values in the fields."
     }
 }

--- a/src/main/webapp/i18n/en/sourceType.json
+++ b/src/main/webapp/i18n/en/sourceType.json
@@ -31,6 +31,7 @@
         }
     },
     "error": {
-        "sourceTypeAvailable" : "A SourceType with given producer,model and version is already available"
+        "sourceTypeAvailable" : "A SourceType with given producer,model and version is already available",
+        "validation": "Validation error, check the entered values in the fields."
     }
 }

--- a/src/main/webapp/i18n/en/subject.json
+++ b/src/main/webapp/i18n/en/subject.json
@@ -66,6 +66,7 @@
     },
     "error": {
         "patientEmailRequired": "A valid email is required to activate the subject account",
-        "subjectExists" : "A subject with given project-id and external-id already exists"
+        "subjectExists" : "A subject with given project-id and external-id already exists",
+        "validation": "Validation error, check the entered values in the fields."
     }
 }

--- a/src/main/webapp/i18n/en/user-management.json
+++ b/src/main/webapp/i18n/en/user-management.json
@@ -39,6 +39,7 @@
         "project" : "Project"
     },
     "error": {
-        "rolesRequired": "One or more roles are required"
+        "rolesRequired": "One or more roles are required",
+        "validation": "Validation error, check the entered values in the fields."
     }
 }

--- a/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
+++ b/src/test/java/org/radarcns/management/service/UserServiceIntTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.radarcns.management.ManagementPortalTestApp;
-import org.radarcns.management.config.Constants;
+import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.dto.UserDTO;

--- a/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SubjectResourceIntTest.java
@@ -69,7 +69,7 @@ public class SubjectResourceIntTest {
     private static final SubjectDTO.SubjectStatus DEFAULT_STATUS = SubjectDTO.SubjectStatus.ACTIVATED;
 
     private static final String MODEL = "App";
-    private static final String PRODUCER ="THINC-IT App";
+    private static final String PRODUCER ="THINC-IT";
     private static final String DEVICE_VERSION = "v1";
 
     @Autowired
@@ -376,7 +376,7 @@ public class SubjectResourceIntTest {
     private MinimalSourceDetailsDTO createSourceWithDeviceId() {
         // Create a source description
         MinimalSourceDetailsDTO sourceRegistrationDTO = new MinimalSourceDetailsDTO();
-        sourceRegistrationDTO.setSourceName(PRODUCER + " " + MODEL);
+        sourceRegistrationDTO.setSourceName(PRODUCER + "-" + MODEL);
         sourceRegistrationDTO.getAttributes().put("some", "value");
 
         List<SourceTypeDTO> sourceTypes = sourceTypeService.findAll().stream()
@@ -394,7 +394,7 @@ public class SubjectResourceIntTest {
     private MinimalSourceDetailsDTO createSourceWithoutDeviceId() {
         // Create a source description
         MinimalSourceDetailsDTO sourceRegistrationDTO = new MinimalSourceDetailsDTO();
-        sourceRegistrationDTO.setSourceName(PRODUCER + " " + MODEL);
+        sourceRegistrationDTO.setSourceName(PRODUCER + "-" + MODEL);
         sourceRegistrationDTO.getAttributes().put("some", "value");
 
         List<SourceTypeDTO> sourceTypes = sourceTypeService.findAll().stream()


### PR DESCRIPTION
All entity fields that are part of the entity's identifier now need to adhere to the regex `^[_'.@A-Za-z0-9-]*$`.

- Frontend correctly encodes special characters in path variables
- Add form validation and messages to entity identifier fields
- Add validation on the relevant domain class fields
- Add exception handler for `TransactionSystemException`
- `Constants` class moved to `radar-auth`

Closes #135 