### PR TITLE
Security update

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/authorization/Permission.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authorization/Permission.java
@@ -165,4 +165,13 @@ public class Permission {
     public String toString() {
         return "Permission{entity=" + entity + ", operation=" + operation + '}';
     }
+
+    /**
+     * Turn this permission into an OAuth scope name and return it
+     *
+     * @return the OAuth scope representation of this permission
+     */
+    public String scopeName() {
+        return entity.name() + "." + operation.name();
+    }
 }

--- a/radar-auth/src/test/java/org/radarcns/auth/unit/authorization/RadarAuthorizationTest.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/unit/authorization/RadarAuthorizationTest.java
@@ -57,13 +57,6 @@ public class RadarAuthorizationTest {
     }
 
     @Test
-    public void testIsSuperUser() {
-        assertFalse(RadarAuthorization.isSuperUser(TokenTestUtils.PROJECT_ADMIN_TOKEN));
-        assertFalse(RadarAuthorization.isSuperUser(TokenTestUtils.SCOPE_TOKEN));
-        assertTrue(RadarAuthorization.isSuperUser(TokenTestUtils.SUPER_USER_TOKEN));
-    }
-
-    @Test
     public void testCheckPermission() {
         DecodedJWT token = TokenTestUtils.SUPER_USER_TOKEN;
         Permission.allPermissions().stream()
@@ -174,7 +167,6 @@ public class RadarAuthorizationTest {
                     fail();
                 });
 
-        assertFalse(RadarAuthorization.isSuperUser(token));
         assertFalse(RadarAuthorization.isJustParticipant(token, ""));
     }
 

--- a/src/main/docker/etc/config/oauth_client_details.csv
+++ b/src/main/docker/etc/config/oauth_client_details.csv
@@ -1,6 +1,7 @@
 client_id;resource_ids;client_secret;scope;authorized_grant_types;redirect_uri;authorities;access_token_validity;refresh_token_validity;additional_information;autoapprove
-pRMT;res_ManagementPortal;secret;SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
-aRMT;res_ManagementPortal;secret;SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
-THINC-IT;res_gateway,res_ManagementPortal;secret;SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
-radar_restapi;res_ManagementPortal,res_gateway;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};
+pRMT;res_ManagementPortal,res_gateway;secret;MEASUREMENT.CREATE,SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
+aRMT;res_ManagementPortal,res_gateway;secret;MEASUREMENT.CREATE,SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
+THINC-IT;res_ManagementPortal,res_gateway;secret;MEASUREMENT.CREATE,SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
+radar_restapi;res_ManagementPortal;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};
 radar_redcap_integrator;res_ManagementPortal;secret;PROJECT.READ,SUBJECT.CREATE,SUBJECT.READ,SUBJECT.UPDATE;client_credentials;;;43200;259200;{};
+radar_dashboard;res_ManagementPortal,res_restApi;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};

--- a/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
+++ b/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
@@ -1,5 +1,6 @@
 package org.radarcns.management.security;
 
+import org.radarcns.auth.authorization.RadarAuthorization;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.SubjectRepository;
@@ -13,6 +14,7 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
@@ -63,7 +65,7 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
                         .map(role -> role.getProject().getProjectName() + ":"
                                 + role.getAuthority().getName())
                         .collect(Collectors.toList());
-                additionalInfo.put("roles", roles);
+                additionalInfo.put(RadarAuthorization.ROLES_CLAIM, roles);
 
             }
 
@@ -72,11 +74,12 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
             List<String> sourceIds = assignedSources.stream()
                     .map(s -> s.getSourceId().toString())
                     .collect(Collectors.toList());
-            additionalInfo.put("sources", sourceIds);
+            additionalInfo.put(RadarAuthorization.SOURCES_CLAIM, sourceIds);
         }
         // add iat and iss optional JWT claims
         additionalInfo.put("iat", Instant.now().getEpochSecond());
         additionalInfo.put("iss", appName);
+        additionalInfo.put(RadarAuthorization.GRANT_TYPE_CLAIM, authentication.getOAuth2Request().getGrantType());
         ((DefaultOAuth2AccessToken) accessToken)
             .setAdditionalInformation(additionalInfo);
 

--- a/src/test/java/org/radarcns/management/web/rest/OAuthHelper.java
+++ b/src/test/java/org/radarcns/management/web/rest/OAuthHelper.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.codec.binary.Base64;
+import org.radarcns.auth.authorization.Permission;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.io.InputStream;
@@ -13,6 +14,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 /**
  * Created by dverbeec on 29/06/2017.
@@ -21,7 +23,7 @@ public class OAuthHelper {
     public static String VALID_TOKEN;
     public static DecodedJWT SUPER_USER_TOKEN;
 
-    public static final String[] SCOPES = {};
+    public static final String[] SCOPES = allScopes();
     public static final String[] AUTHORITIES = {"ROLE_SYS_ADMIN"};
     public static final String[] ROLES = {};
     public static final String[] SOURCES = {};
@@ -88,7 +90,14 @@ public class OAuthHelper {
                 .withClaim("client_id", CLIENT)
                 .withClaim("user_name", USER)
                 .withClaim("jti", JTI)
+                .withClaim("grant_type", "password")
                 .sign(algorithm);
         SUPER_USER_TOKEN = JWT.decode(VALID_TOKEN);
+    }
+
+    private static String[] allScopes() {
+        return Permission.allPermissions().stream()
+                .map(Permission::scopeName)
+                .collect(Collectors.toList()).toArray(new String[Permission.allPermissions().size()]);
     }
 }


### PR DESCRIPTION
JWT's now need the correct scope in addition to the correct user authority. This allows a user to authorize certain applications for certain scopes, instead of the application automatically 'inheriting' all user authorities.

Closes #144 