### PR TITLE
Adding sourcename appending logic

### DIFF
--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -242,8 +242,18 @@ public class SubjectService {
                 source1.getAttributes().putAll(sourceRegistrationDTO.getAttributes());
                 // if source name is provided update source name
                 if (Objects.nonNull(sourceRegistrationDTO.getSourceName())) {
-                    // append the generated source-name to given source-name to avoid conflicts
+                    // append the auto generated source-name to given source-name to avoid conflicts
                     source1.setSourceName(sourceRegistrationDTO.getSourceName()+"_"+source1.getSourceName());
+                }
+
+                Optional<Source> sourceToUpdate = sourceRepository.findOneBySourceName(source1.getSourceName());
+                if(sourceToUpdate.isPresent()) {
+                    log.error("Cannot create a source with existing source-name {}" , source1.getSourceName());
+                    Map<String, String> errorParams = new HashMap<>();
+                    errorParams.put("message",
+                        "SourceName already in use. Cannot create a source with source-name ");
+                    errorParams.put("source-name", source1.getSourceName());
+                    throw new CustomNotFoundException("Conflict", errorParams);
                 }
                 source1 = sourceRepository.save(source1);
 

--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -242,7 +242,8 @@ public class SubjectService {
                 source1.getAttributes().putAll(sourceRegistrationDTO.getAttributes());
                 // if source name is provided update source name
                 if (Objects.nonNull(sourceRegistrationDTO.getSourceName())) {
-                    source1.setSourceName(sourceRegistrationDTO.getSourceName());
+                    // append the generated source-name to given source-name to avoid conflicts
+                    source1.setSourceName(sourceRegistrationDTO.getSourceName()+"_"+source1.getSourceName());
                 }
                 source1 = sourceRepository.save(source1);
 


### PR DESCRIPTION
We should append the auto generated source-name if a sourceName is already provided by the client to avoid conflicts on creation. 
This is feature required to support pRMT or any other clients who would do a dynamic source registration with a source-name. 

Fixes #160 