### PR TITLE
Fix for not crashing on null grant type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group 'org.radarcns'
-    version '0.3.2-SNAPSHOT'
+    version '0.3.1'
 
     apply plugin: 'java'
     apply plugin: 'java-library'

--- a/radar-auth/src/main/java/org/radarcns/auth/authorization/RadarAuthorization.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authorization/RadarAuthorization.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -165,6 +166,6 @@ public class RadarAuthorization {
     }
 
     private static boolean isClientCredentials(DecodedJWT token) {
-        return token.getClaim(GRANT_TYPE_CLAIM).asString().equals(CLIENT_CREDENTIALS);
+        return CLIENT_CREDENTIALS.equals(token.getClaim(GRANT_TYPE_CLAIM).asString());
     }
 }


### PR DESCRIPTION
Fix for crash on `null` grant type. It turns out `OAuth2Request.getGrantType()` returns `null` for access tokens acquired using a refresh token.