### PR TITLE
Add style definitions to main project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,21 @@ if (OperatingSystem.current().isWindows()) {
     }
 }
 
+checkstyle {
+    toolVersion '6.16'
+    ignoreFailures true
+}
+
+pmd {
+    toolVersion = '5.5.2'
+    ignoreFailures = true
+
+    consoleOutput = true
+
+    ruleSets = []
+    ruleSetFiles = files("config/pmd/ruleset.xml")
+}
+
 test {
     include '**/*UnitTest*'
     include '**/*IntTest*'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="SuppressWarningsFilter" />
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="100"/>
+        </module>
+        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="8"/>
+            <property name="lineWrappingIndentation" value="8"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="MethodParamPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+        <module name="SuppressWarningsHolder" />
+    </module>
+</module>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<ruleset name="Ruleset from Codacy"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>
+  This ruleset was parsed from the Codacy default codestyle.
+  </description>
+
+  <rule ref="rulesets/java/logging-jakarta-commons.xml/ProperLogger"/>
+  <rule ref="rulesets/java/imports.xml/DontImportJavaLang"/>
+  <rule ref="rulesets/java/strings.xml/StringInstantiation"/>
+  <rule ref="rulesets/java/junit.xml/SimplifyBooleanAssertion"/>
+  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
+  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingNullPointerException"/>
+  <rule ref="rulesets/java/imports.xml/UnusedImports"/>
+  <rule ref="rulesets/java/strings.xml/UseEqualsToCompareStrings"/>
+  <rule ref="rulesets/java/basic.xml/CheckResultSet"/>
+  <rule ref="rulesets/java/strings.xml/StringToString"/>
+  <rule ref="rulesets/java/naming.xml/ClassNamingConventions"/>
+  <rule ref="rulesets/java/design.xml/CompareObjectsWithEquals"/>
+  <rule ref="rulesets/java/naming.xml/MethodNamingConventions"/>
+  <rule ref="rulesets/java/naming.xml/GenericsNaming"/>
+  <rule ref="rulesets/java/design.xml/LogicInversion"/>
+  <rule ref="rulesets/java/naming.xml/NoPackage"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength"/>
+  <rule ref="rulesets/java/codesize.xml/NPathComplexity"/>
+  <rule ref="rulesets/java/controversial.xml/OneDeclarationPerLine"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveParameterList"/>
+  <rule ref="rulesets/java/controversial.xml/DefaultPackage"/>
+  <rule ref="rulesets/java/imports.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="rulesets/java/junit.xml/JUnitTestsShouldIncludeAssert"/>
+  <rule ref="rulesets/java/unnecessary.xml/UselessOperationOnImmutable"/>
+  <rule ref="rulesets/java/basic.xml/AvoidBranchingStatementAsLastInLoop"/>
+  <rule ref="rulesets/java/empty.xml/EmptyFinallyBlock"/>
+  <rule ref="rulesets/java/empty.xml/EmptyIfStmt"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStatementNotInLoop"/>
+  <rule ref="rulesets/java/empty.xml/EmptyTryBlock"/>
+  <rule ref="rulesets/java/basic.xml/ExtendsObject"/>
+  <rule ref="rulesets/java/design.xml/SingularField"/>
+  <rule ref="rulesets/java/design.xml/SimplifyBooleanReturns"/>
+  <rule ref="rulesets/java/design.xml/AvoidInstanceofChecksInCatchClause"/>
+  <rule ref="rulesets/java/basic.xml/BooleanInstantiation"/>
+  <rule ref="rulesets/java/basic.xml/JumbledIncrementer"/>
+  <rule ref="rulesets/java/basic.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+  <rule ref="rulesets/java/naming.xml/MethodWithSameNameAsEnclosingClass"/>
+  <rule ref="rulesets/java/basic.xml/MisplacedNullCheck"/>
+  <rule ref="rulesets/java/basic.xml/CollapsibleIfStatements"/>
+  <rule ref="rulesets/java/design.xml/NonCaseLabelInSwitchStatement"/>
+  <rule ref="rulesets/java/design.xml/NonStaticInitializer"/>
+  <rule ref="rulesets/java/controversial.xml/UnnecessaryConstructor"/>
+  <rule ref="rulesets/java/design.xml/AvoidReassigningParameters"/>
+  <rule ref="rulesets/java/basic.xml/ReturnFromFinallyBlock"/>
+  <rule ref="rulesets/java/design.xml/SwitchStmtsShouldHaveDefault"/>
+  <rule ref="rulesets/java/design.xml/MissingBreakInSwitch"/>
+  <rule ref="rulesets/java/design.xml/EqualsNull"/>
+  <rule ref="rulesets/java/finalizers.xml/AvoidCallingFinalize"/>
+  <rule ref="rulesets/java/finalizers.xml/EmptyFinalizer"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStatementBlock"/>
+  <rule ref="rulesets/java/basic.xml/AvoidThreadGroup"/>
+  <rule ref="rulesets/java/basic.xml/DontCallThreadRun"/>
+  <rule ref="rulesets/java/basic.xml/BrokenNullCheck"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStaticInitializer"/>
+  <rule ref="rulesets/java/empty.xml/EmptyInitializer"/>
+  <rule ref="rulesets/java/empty.xml/EmptySwitchStatements"/>
+  <rule ref="rulesets/java/empty.xml/EmptySynchronizedBlock"/>
+  <rule ref="rulesets/java/basic.xml/DontUseFloatTypeForLoopIndices"/>
+  <rule ref="rulesets/java/basic.xml/AvoidMultipleUnaryOperators"/>
+  <rule ref="rulesets/java/basic.xml/CheckSkipResult"/>
+  <rule ref="rulesets/java/unnecessary.xml/UnnecessaryReturn"/>
+  <rule ref="rulesets/java/design.xml/UncommentedEmptyMethodBody"/>
+  <rule ref="rulesets/java/design.xml/SimplifyBooleanExpressions"/>
+  <rule ref="rulesets/java/design.xml/AssignmentToNonFinalStatic"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod"/>
+  <rule ref="rulesets/java/naming.xml/PackageCase"/>
+  <rule ref="rulesets/java/design.xml/MissingStaticMethodInNonInstantiatableClass"/>
+  <rule ref="rulesets/java/basic.xml/UnconditionalIfStatement"/>
+  <rule ref="rulesets/java/braces.xml/WhileLoopsMustUseBraces"/>
+  <rule ref="rulesets/java/javabeans.xml/MissingSerialVersionUID"/>
+  <rule ref="rulesets/java/junit.xml/JUnitSpelling"/>
+  <rule ref="rulesets/java/junit.xml/JUnitStaticSuite"/>
+  <rule ref="rulesets/java/junit.xml/UnnecessaryBooleanAssertion"/>
+  <rule ref="rulesets/java/strings.xml/UseStringBufferLength"/>
+  <rule ref="rulesets/java/strings.xml/UnnecessaryCaseChange"/>
+
+<!--
+  Rules part of PMD and Codacy but not enabled:
+  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveClassLength"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessivePublicCount"/>
+  <rule ref="rulesets/java/codesize.xml/TooManyFields"/>
+  <rule ref="rulesets/java/codesize.xml/TooManyMethods"/>
+  <rule ref="rulesets/java/naming.xml/ShortVariable"/>
+  <rule ref="rulesets/java/naming.xml/LongVariable"/>
+  <rule ref="rulesets/java/naming.xml/ShortMethodName"/>
+  <rule ref="rulesets/java/naming.xml/BooleanGetMethodName"/>
+  <rule ref="rulesets/java/android.xml/DoNotHardCodeSDCard"/>
+  <rule ref="rulesets/java/j2ee.xml/DoNotCallSystemExit"/>
+  <rule ref="rulesets/java/design.xml/PositionLiteralsFirstInComparisons"/>
+ -->
+ 
+ <!--
+  Rules part of Codacy but only part of PHPMD:
+  <rule ref="rulesets/java/codesize.xml/ExcessiveClassComplexity"/> 
+  <rule ref="rulesets/java/controversial.xml/Superglobals"/>
+  <rule ref="rulesets/java/design.xml/ExitExpression"/>
+  <rule ref="rulesets/java/design.xml/EvalExpression"/>
+  <rule ref="rulesets/java/design.xml/GotoStatement"/>
+  <rule ref="rulesets/java/design.xml/NumberOfChildren"/>
+  <rule ref="rulesets/java/design.xml/DepthOfInheritance"/>
+  <rule ref="rulesets/java/naming.xml/ConstantNamingConventions"/>
+  <rule ref="rulesets/java/cleancode.xml/ElseExpression"/>
+  <rule ref="rulesets/java/cleancode.xml/StaticAccess"/>
+-->
+</ruleset>

--- a/config/pmd/test_ruleset.xml
+++ b/config/pmd/test_ruleset.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<ruleset name="Ruleset from Codacy"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>
+  This ruleset was parsed from the Codacy default codestyle.
+  </description>
+
+  <rule ref="rulesets/java/logging-jakarta-commons.xml/ProperLogger"/>
+  <rule ref="rulesets/java/imports.xml/DontImportJavaLang"/>
+  <rule ref="rulesets/java/strings.xml/StringInstantiation"/>
+  <rule ref="rulesets/java/junit.xml/SimplifyBooleanAssertion"/>
+  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
+  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingNullPointerException"/>
+  <rule ref="rulesets/java/imports.xml/UnusedImports"/>
+  <rule ref="rulesets/java/strings.xml/UseEqualsToCompareStrings"/>
+  <rule ref="rulesets/java/basic.xml/CheckResultSet"/>
+  <rule ref="rulesets/java/strings.xml/StringToString"/>
+  <rule ref="rulesets/java/naming.xml/ClassNamingConventions"/>
+  <rule ref="rulesets/java/design.xml/CompareObjectsWithEquals"/>
+  <!-- Allow underscores in test methods <rule ref="rulesets/java/naming.xml/MethodNamingConventions"/> -->
+  <rule ref="rulesets/java/naming.xml/GenericsNaming"/>
+  <rule ref="rulesets/java/design.xml/LogicInversion"/>
+  <rule ref="rulesets/java/naming.xml/NoPackage"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength"/>
+  <rule ref="rulesets/java/codesize.xml/NPathComplexity"/>
+  <rule ref="rulesets/java/controversial.xml/OneDeclarationPerLine"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveParameterList"/>
+  <rule ref="rulesets/java/controversial.xml/DefaultPackage"/>
+  <rule ref="rulesets/java/imports.xml/UnnecessaryFullyQualifiedName"/>
+  <rule ref="rulesets/java/junit.xml/JUnitTestsShouldIncludeAssert"/>
+  <rule ref="rulesets/java/unnecessary.xml/UselessOperationOnImmutable"/>
+  <rule ref="rulesets/java/basic.xml/AvoidBranchingStatementAsLastInLoop"/>
+  <rule ref="rulesets/java/empty.xml/EmptyFinallyBlock"/>
+  <rule ref="rulesets/java/empty.xml/EmptyIfStmt"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStatementNotInLoop"/>
+  <rule ref="rulesets/java/empty.xml/EmptyTryBlock"/>
+  <rule ref="rulesets/java/basic.xml/ExtendsObject"/>
+  <rule ref="rulesets/java/design.xml/SingularField"/>
+  <rule ref="rulesets/java/design.xml/SimplifyBooleanReturns"/>
+  <rule ref="rulesets/java/design.xml/AvoidInstanceofChecksInCatchClause"/>
+  <rule ref="rulesets/java/basic.xml/BooleanInstantiation"/>
+  <rule ref="rulesets/java/basic.xml/JumbledIncrementer"/>
+  <rule ref="rulesets/java/basic.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+  <rule ref="rulesets/java/naming.xml/MethodWithSameNameAsEnclosingClass"/>
+  <rule ref="rulesets/java/basic.xml/MisplacedNullCheck"/>
+  <rule ref="rulesets/java/basic.xml/CollapsibleIfStatements"/>
+  <rule ref="rulesets/java/design.xml/NonCaseLabelInSwitchStatement"/>
+  <rule ref="rulesets/java/design.xml/NonStaticInitializer"/>
+  <rule ref="rulesets/java/controversial.xml/UnnecessaryConstructor"/>
+  <rule ref="rulesets/java/design.xml/AvoidReassigningParameters"/>
+  <rule ref="rulesets/java/basic.xml/ReturnFromFinallyBlock"/>
+  <rule ref="rulesets/java/design.xml/SwitchStmtsShouldHaveDefault"/>
+  <rule ref="rulesets/java/design.xml/MissingBreakInSwitch"/>
+  <!-- Testing equals functions <rule ref="rulesets/java/design.xml/EqualsNull"/> -->
+  <rule ref="rulesets/java/finalizers.xml/AvoidCallingFinalize"/>
+  <rule ref="rulesets/java/finalizers.xml/EmptyFinalizer"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStatementBlock"/>
+  <rule ref="rulesets/java/basic.xml/AvoidThreadGroup"/>
+  <rule ref="rulesets/java/basic.xml/DontCallThreadRun"/>
+  <rule ref="rulesets/java/basic.xml/BrokenNullCheck"/>
+  <rule ref="rulesets/java/empty.xml/EmptyStaticInitializer"/>
+  <rule ref="rulesets/java/empty.xml/EmptyInitializer"/>
+  <rule ref="rulesets/java/empty.xml/EmptySwitchStatements"/>
+  <rule ref="rulesets/java/empty.xml/EmptySynchronizedBlock"/>
+  <rule ref="rulesets/java/basic.xml/DontUseFloatTypeForLoopIndices"/>
+  <rule ref="rulesets/java/basic.xml/AvoidMultipleUnaryOperators"/>
+  <rule ref="rulesets/java/basic.xml/CheckSkipResult"/>
+  <rule ref="rulesets/java/unnecessary.xml/UnnecessaryReturn"/>
+  <rule ref="rulesets/java/design.xml/UncommentedEmptyMethodBody"/>
+  <rule ref="rulesets/java/design.xml/SimplifyBooleanExpressions"/>
+  <rule ref="rulesets/java/design.xml/AssignmentToNonFinalStatic"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField"/>
+  <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod"/>
+  <rule ref="rulesets/java/naming.xml/PackageCase"/>
+  <rule ref="rulesets/java/design.xml/MissingStaticMethodInNonInstantiatableClass"/>
+  <rule ref="rulesets/java/basic.xml/UnconditionalIfStatement"/>
+  <rule ref="rulesets/java/braces.xml/WhileLoopsMustUseBraces"/>
+  <rule ref="rulesets/java/javabeans.xml/MissingSerialVersionUID"/>
+  <rule ref="rulesets/java/junit.xml/JUnitSpelling"/>
+  <rule ref="rulesets/java/junit.xml/JUnitStaticSuite"/>
+  <rule ref="rulesets/java/junit.xml/UnnecessaryBooleanAssertion"/>
+  <rule ref="rulesets/java/strings.xml/UseStringBufferLength"/>
+  <rule ref="rulesets/java/strings.xml/UnnecessaryCaseChange"/>
+
+<!--
+  Rules part of PMD and Codacy but not enabled:
+  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessiveClassLength"/>
+  <rule ref="rulesets/java/codesize.xml/ExcessivePublicCount"/>
+  <rule ref="rulesets/java/codesize.xml/TooManyFields"/>
+  <rule ref="rulesets/java/codesize.xml/TooManyMethods"/>
+  <rule ref="rulesets/java/naming.xml/ShortVariable"/>
+  <rule ref="rulesets/java/naming.xml/LongVariable"/>
+  <rule ref="rulesets/java/naming.xml/ShortMethodName"/>
+  <rule ref="rulesets/java/naming.xml/BooleanGetMethodName"/>
+  <rule ref="rulesets/java/android.xml/DoNotHardCodeSDCard"/>
+  <rule ref="rulesets/java/j2ee.xml/DoNotCallSystemExit"/>
+  <rule ref="rulesets/java/design.xml/PositionLiteralsFirstInComparisons"/>
+ -->
+ 
+ <!--
+  Rules part of Codacy but only part of PHPMD:
+  <rule ref="rulesets/java/codesize.xml/ExcessiveClassComplexity"/> 
+  <rule ref="rulesets/java/controversial.xml/Superglobals"/>
+  <rule ref="rulesets/java/design.xml/ExitExpression"/>
+  <rule ref="rulesets/java/design.xml/EvalExpression"/>
+  <rule ref="rulesets/java/design.xml/GotoStatement"/>
+  <rule ref="rulesets/java/design.xml/NumberOfChildren"/>
+  <rule ref="rulesets/java/design.xml/DepthOfInheritance"/>
+  <rule ref="rulesets/java/naming.xml/ConstantNamingConventions"/>
+  <rule ref="rulesets/java/cleancode.xml/ElseExpression"/>
+  <rule ref="rulesets/java/cleancode.xml/StaticAccess"/>
+-->
+</ruleset>

--- a/src/main/java/org/radarcns/management/config/LocalKeystoreConfig.java
+++ b/src/main/java/org/radarcns/management/config/LocalKeystoreConfig.java
@@ -13,7 +13,7 @@ import java.security.interfaces.RSAPublicKey;
  */
 public class LocalKeystoreConfig implements ServerConfig {
 
-    RSAPublicKey publicKey;
+    private RSAPublicKey publicKey;
 
     public LocalKeystoreConfig() {
         KeyPair keyPair = new KeyStoreKeyFactory(

--- a/src/main/java/org/radarcns/management/config/OAuth2LoginUiWebConfig.java
+++ b/src/main/java/org/radarcns/management/config/OAuth2LoginUiWebConfig.java
@@ -1,7 +1,15 @@
 package org.radarcns.management.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
@@ -14,18 +22,6 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.HtmlUtils;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 /**
  * Created by dverbeec on 6/07/2017.
  */
@@ -34,9 +30,7 @@ import java.util.stream.Stream;
 public class OAuth2LoginUiWebConfig {
 
     @Autowired
-    ClientDetailsService clientDetailsService;
-
-    private Logger log = LoggerFactory.getLogger(OAuth2LoginUiWebConfig.class);
+    private ClientDetailsService clientDetailsService;
 
     @RequestMapping("/login")
     public ModelAndView getLogin(HttpServletRequest request, HttpServletResponse response) throws

--- a/src/main/java/org/radarcns/management/config/SecurityConfiguration.java
+++ b/src/main/java/org/radarcns/management/config/SecurityConfiguration.java
@@ -40,7 +40,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private UserDetailsService userDetailsService;
 
     @Autowired
-    ApplicationEventPublisher applicationEventPublisher;
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/org/radarcns/management/config/WebConfigurer.java
+++ b/src/main/java/org/radarcns/management/config/WebConfigurer.java
@@ -1,20 +1,27 @@
 package org.radarcns.management.config;
 
-import io.github.jhipster.config.JHipsterConstants;
-import io.github.jhipster.config.JHipsterProperties;
-import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.servlet.InstrumentedFilter;
 import com.codahale.metrics.servlets.MetricsServlet;
-import com.hazelcast.core.HazelcastInstance;
-
+import io.github.jhipster.config.JHipsterConstants;
+import io.github.jhipster.config.JHipsterProperties;
+import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
+import io.undertow.UndertowOptions;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.EnumSet;
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.*;
+import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.MimeMappings;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
-import io.undertow.UndertowOptions;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,11 +29,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-
-import java.io.File;
-import java.nio.file.Paths;
-import java.util.*;
-import javax.servlet.*;
 
 /**
  * Configuration of web application with Servlet 3.0 APIs.
@@ -41,9 +43,6 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
 
     @Autowired
     private JHipsterProperties jHipsterProperties;
-
-    @Autowired
-    private HazelcastInstance hazelcastInstance;
 
     @Autowired(required = false)
     private MetricRegistry metricRegistry;

--- a/src/main/java/org/radarcns/management/domain/Authority.java
+++ b/src/main/java/org/radarcns/management/domain/Authority.java
@@ -1,6 +1,7 @@
 package org.radarcns.management.domain;
 
 import java.io.Serializable;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -50,11 +51,12 @@ public class Authority implements Serializable {
 
         Authority authority = (Authority) o;
 
-        if (name != null ? !name.equals(authority.name) : authority.name != null) {
+
+        if (name == null || authority.name == null ) {
             return false;
         }
 
-        return true;
+        return Objects.equals(name, authority.name);
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/domain/PersistentAuditEvent.java
+++ b/src/main/java/org/radarcns/management/domain/PersistentAuditEvent.java
@@ -16,6 +16,8 @@ import javax.validation.constraints.NotNull;
 @Table(name = "jhi_persistent_audit_event")
 public class PersistentAuditEvent implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
     @SequenceGenerator(name = "sequenceGenerator", initialValue = 1000)

--- a/src/main/java/org/radarcns/management/domain/Project.java
+++ b/src/main/java/org/radarcns/management/domain/Project.java
@@ -79,7 +79,7 @@ public class Project extends AbstractAuditingEntity implements Serializable {
     @MapKeyColumn(name="attribute_key")
     @Column(name="attribute_value")
     @CollectionTable(name="project_metadata" ,  joinColumns = @JoinColumn(name = "id"))
-    Map<String, String> attributes = new HashMap<>();
+    private Map<String, String> attributes = new HashMap<>();
 
     public Long getId() {
         return id;

--- a/src/main/java/org/radarcns/management/domain/Source.java
+++ b/src/main/java/org/radarcns/management/domain/Source.java
@@ -76,7 +76,7 @@ public class Source extends AbstractAuditingEntity implements Serializable {
     @MapKeyColumn(name="attribute_key")
     @Column(name="attribute_value")
     @CollectionTable(name="source_metadata" ,  joinColumns = @JoinColumn(name = "id"))
-    Map<String, String> attributes = new HashMap<String, String>(); // maps from attribute name to value
+    private Map<String, String> attributes = new HashMap<String, String>(); // maps from attribute name to value
 
     public Long getId() {
         return id;

--- a/src/main/java/org/radarcns/management/domain/Subject.java
+++ b/src/main/java/org/radarcns/management/domain/Subject.java
@@ -56,7 +56,7 @@ public class Subject extends AbstractAuditingEntity implements Serializable {
     @Column(name="attribute_value")
     @CollectionTable(name="subject_metadata" ,  joinColumns = @JoinColumn(name = "id"))
     @Cascade(CascadeType.ALL)
-    Map<String, String> attributes = new HashMap<>();
+    private Map<String, String> attributes = new HashMap<>();
 
     public Long getId() {
         return id;

--- a/src/main/java/org/radarcns/management/domain/User.java
+++ b/src/main/java/org/radarcns/management/domain/User.java
@@ -89,15 +89,15 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @Column(name = "reset_date")
     private ZonedDateTime resetDate = null;
 
-    @JsonIgnore
-    @ManyToMany()
-    @JoinTable(
-        name = "radar_user_authority",
-        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
-        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    @BatchSize(size = 20)
-    private Set<Authority> authorities = new HashSet<>();
+//    @JsonIgnore
+//    @ManyToMany()
+//    @JoinTable(
+//        name = "radar_user_authority",
+//        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
+//        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
+//    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+//    @BatchSize(size = 20)
+//    private Set<Authority> authorities = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(

--- a/src/main/java/org/radarcns/management/domain/User.java
+++ b/src/main/java/org/radarcns/management/domain/User.java
@@ -89,15 +89,15 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @Column(name = "reset_date")
     private ZonedDateTime resetDate = null;
 
-//    @JsonIgnore
-//    @ManyToMany()
-//    @JoinTable(
-//        name = "radar_user_authority",
-//        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
-//        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
-//    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-//    @BatchSize(size = 20)
-//    private Set<Authority> authorities = new HashSet<>();
+    @JsonIgnore
+    @ManyToMany()
+    @JoinTable(
+        name = "radar_user_authority",
+        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
+        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @BatchSize(size = 20)
+    private Set<Authority> authorities = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(

--- a/src/main/java/org/radarcns/management/filters/OAuth2TokenRequestPreZuulFilter.java
+++ b/src/main/java/org/radarcns/management/filters/OAuth2TokenRequestPreZuulFilter.java
@@ -3,8 +3,6 @@ package org.radarcns.management.filters;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import java.io.UnsupportedEncodingException;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 import org.radarcns.management.config.ManagementPortalProperties;
 import org.slf4j.Logger;
@@ -20,11 +18,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class OAuth2TokenRequestPreZuulFilter extends ZuulFilter {
 
-    static final String REFRESH_TOKEN_COOKIE = "rft";
+    protected static final String REFRESH_TOKEN_COOKIE = "rft";
     @Autowired
     private  ManagementPortalProperties managementPortalProperties;
 
-    Logger logger = LoggerFactory.getLogger(OAuth2TokenRequestPreZuulFilter.class);
+    private Logger logger = LoggerFactory.getLogger(OAuth2TokenRequestPreZuulFilter.class);
     @Override
     public Object run() {
         RequestContext ctx = RequestContext.getCurrentContext();
@@ -40,17 +38,17 @@ public class OAuth2TokenRequestPreZuulFilter extends ZuulFilter {
         return null;
     }
 
-    private String extractRefreshToken(HttpServletRequest req) {
-        final Cookie[] cookies = req.getCookies();
-        if (cookies != null) {
-            for (int i = 0; i < cookies.length; i++) {
-                if (cookies[i].getName().equalsIgnoreCase(REFRESH_TOKEN_COOKIE)) {
-                    return cookies[i].getValue();
-                }
-            }
-        }
-        return null;
-    }
+//    private String extractRefreshToken(HttpServletRequest req) {
+//        final Cookie[] cookies = req.getCookies();
+//        if (cookies != null) {
+//            for (int i = 0; i < cookies.length; i++) {
+//                if (cookies[i].getName().equalsIgnoreCase(REFRESH_TOKEN_COOKIE)) {
+//                    return cookies[i].getValue();
+//                }
+//            }
+//        }
+//        return null;
+//    }
 
     @Override
     public boolean shouldFilter() {

--- a/src/main/java/org/radarcns/management/repository/AuthorityRepository.java
+++ b/src/main/java/org/radarcns/management/repository/AuthorityRepository.java
@@ -2,8 +2,6 @@ package org.radarcns.management.repository;
 
 import java.util.List;
 import org.radarcns.management.domain.Authority;
-
-import org.radarcns.management.domain.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/org/radarcns/management/repository/UserRepository.java
+++ b/src/main/java/org/radarcns/management/repository/UserRepository.java
@@ -1,17 +1,13 @@
 package org.radarcns.management.repository;
 
-import org.radarcns.management.domain.Subject;
-import org.radarcns.management.domain.User;
-
 import java.time.ZonedDateTime;
-
+import java.util.List;
+import java.util.Optional;
+import org.radarcns.management.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 

--- a/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
+++ b/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
@@ -1,5 +1,12 @@
 package org.radarcns.management.security;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.radarcns.auth.authorization.RadarAuthorization;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.domain.User;
@@ -14,19 +21,9 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
-import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
-import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
 import org.springframework.security.oauth2.provider.token.TokenEnhancer;
-
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
 
@@ -97,6 +94,7 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
+        // nothing to do for now
     }
 
     private Map<String, Object> auditData(OAuth2AccessToken accessToken,

--- a/src/main/java/org/radarcns/management/service/MailService.java
+++ b/src/main/java/org/radarcns/management/service/MailService.java
@@ -1,11 +1,10 @@
 package org.radarcns.management.service;
 
+import java.util.Locale;
+import javax.mail.internet.MimeMessage;
+import org.apache.commons.lang3.CharEncoding;
 import org.radarcns.management.config.ManagementPortalProperties;
 import org.radarcns.management.domain.User;
-
-import io.github.jhipster.config.JHipsterProperties;
-
-import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -15,9 +14,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring4.SpringTemplateEngine;
-
-import javax.mail.internet.MimeMessage;
-import java.util.Locale;
 
 /**
  * Service for sending emails.

--- a/src/main/java/org/radarcns/management/service/ProjectService.java
+++ b/src/main/java/org/radarcns/management/service/ProjectService.java
@@ -1,21 +1,19 @@
 package org.radarcns.management.service;
 
 
-import org.radarcns.management.domain.SourceType;
+import java.util.List;
 import org.radarcns.management.domain.Project;
+import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.repository.ProjectRepository;
-import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.dto.ProjectDTO;
-import org.radarcns.management.service.mapper.SourceTypeMapper;
+import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.mapper.ProjectMapper;
-import org.radarcns.management.service.mapper.UserMapper;
+import org.radarcns.management.service.mapper.SourceTypeMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /**
  * Service Implementation for managing Project.
@@ -35,11 +33,6 @@ public class ProjectService {
     @Autowired
     private SourceTypeMapper sourceTypeMapper;
 
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private UserMapper userMapper;
 
     /**
      * Save a project.
@@ -62,40 +55,6 @@ public class ProjectService {
      */
     @Transactional(readOnly = true)
     public List findAll(Boolean fetchMinimal) {
-//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-//        List<String> currentUserAuthorities = authentication.getAuthorities().stream()
-//            .map(GrantedAuthority::getAuthority)
-//            .collect(Collectors.toList());
-//
-//        List<Project> projects = new LinkedList<>();
-//        if(currentUserAuthorities.contains(AuthoritiesConstants.SYS_ADMIN) ||
-//            currentUserAuthorities.contains(AuthoritiesConstants.EXTERNAL_ERF_INTEGRATOR)) {
-//            log.debug("Request to get all Projects");
-//            projects = projectRepository.findAllWithEagerRelationships();
-//        }
-//        else if(currentUserAuthorities.contains(AuthoritiesConstants.PROJECT_ADMIN)) {
-//            log.debug("Request to get project admin's project Projects");
-//            String name = authentication.getName();
-//            Optional<UserDTO> user = userService.getUserWithAuthoritiesByLogin(name);
-//            if (user.isPresent()) {
-//                User currentUser = userMapper.userDTOToUser(user.get());
-//                List<Role> pAdminRoles = currentUser.getRoles().stream()
-//                    // get all roles that are a PROJECT_ADMIN role
-//                    .filter(r -> r.getAuthority().getName().equals(AuthoritiesConstants.PROJECT_ADMIN))
-//                    .collect(Collectors.toList());
-//                pAdminRoles.stream()
-//                    .forEach(r -> log.debug("Found PROJECT_ADMIN role for project with id {}",
-//                        r.getProject().getId()));
-//                projects.addAll(pAdminRoles.stream()
-//                    // map them into projects
-//                    .map(r -> projectRepository.findOneWithEagerRelationships(r.getProject().getId()))
-//                    .collect(Collectors.toList()));
-//            }
-//            else {
-//                log.debug("Could find a user with name {}", name);
-//            }
-//        }
-
         List<Project> projects = projectRepository.findAllWithEagerRelationships();
         if(!fetchMinimal){
             return projectMapper.projectsToProjectDTOs(projects);

--- a/src/main/java/org/radarcns/management/service/SubjectService.java
+++ b/src/main/java/org/radarcns/management/service/SubjectService.java
@@ -1,10 +1,18 @@
 package org.radarcns.management.service;
 
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
-import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.domain.Project;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.Source;
+import org.radarcns.management.domain.SourceType;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.AuthorityRepository;
@@ -17,7 +25,6 @@ import org.radarcns.management.service.dto.SubjectDTO;
 import org.radarcns.management.service.mapper.ProjectMapper;
 import org.radarcns.management.service.mapper.SourceMapper;
 import org.radarcns.management.service.mapper.SubjectMapper;
-import org.radarcns.management.service.mapper.UserMapper;
 import org.radarcns.management.service.util.RandomUtil;
 import org.radarcns.management.web.rest.errors.CustomConflictException;
 import org.radarcns.management.web.rest.errors.CustomNotFoundException;
@@ -28,15 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Created by nivethika on 26-5-17.
@@ -51,9 +49,6 @@ public class SubjectService {
     private SubjectMapper subjectMapper;
 
     @Autowired
-    private UserMapper userMapper;
-
-    @Autowired
     private ProjectMapper projectMapper;
 
     @Autowired
@@ -61,9 +56,6 @@ public class SubjectService {
 
     @Autowired
     private AuthorityRepository authorityRepository;
-
-    @Autowired
-    private SourceService sourceService;
 
     @Autowired
     private SourceRepository sourceRepository;
@@ -75,13 +67,7 @@ public class SubjectService {
     private RoleRepository roleRepository;
 
     @Autowired
-    private MailService mailService;
-
-    @Autowired
     private PasswordEncoder passwordEncoder;
-
-    @Autowired
-    private UserService userService;
 
 
     @Transactional

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -1,5 +1,12 @@
 package org.radarcns.management.service;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Project;
@@ -14,7 +21,6 @@ import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.dto.RoleDTO;
 import org.radarcns.management.service.dto.UserDTO;
 import org.radarcns.management.service.mapper.ProjectMapper;
-import org.radarcns.management.service.mapper.RoleMapper;
 import org.radarcns.management.service.mapper.UserMapper;
 import org.radarcns.management.service.util.RandomUtil;
 import org.slf4j.Logger;
@@ -26,14 +32,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * Service class for managing users.
@@ -64,9 +62,6 @@ public class UserService {
 
     @Autowired
     private  AuthorityRepository authorityRepository;
-
-    @Autowired
-    private RoleMapper roleMapper;
 
     public Optional<User> activateRegistration(String key) {
         log.debug("Activating user for activation key {}", key);

--- a/src/main/java/org/radarcns/management/service/catalog/CatalogSourceData.java
+++ b/src/main/java/org/radarcns/management/service/catalog/CatalogSourceData.java
@@ -2,12 +2,8 @@ package org.radarcns.management.service.catalog;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CatalogSourceData {
-
-    private static final Logger logger = LoggerFactory.getLogger(CatalogSourceData.class);
 
     @JsonProperty("app_provider")
     private String appProvider;

--- a/src/main/java/org/radarcns/management/service/dto/ClientDetailsDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/ClientDetailsDTO.java
@@ -19,10 +19,6 @@ public class ClientDetailsDTO {
     private Set<String> registeredRedirectUri;
     private Map<String, String> additionalInformation;
 
-    public ClientDetailsDTO() {
-
-    }
-
     /**
      * Get the ClientId
      *

--- a/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/ProjectDTO.java
@@ -14,6 +14,8 @@ import org.radarcns.management.domain.enumeration.ProjectStatus;
  */
 public class ProjectDTO implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     public static final String EXTERNAL_PROJECT_URL_KEY = "External-project-url";
     public static final String EXTERNAL_PROJECT_ID_KEY = "External-project-id";
     public static final String WORK_PACKAGE_KEY = "Work-package";
@@ -134,10 +136,11 @@ public class ProjectDTO implements Serializable {
         }
 
         ProjectDTO projectDTO = (ProjectDTO) o;
+        if (id ==null || projectDTO.id ==null) {
+            return  false;
+        }
 
-        if ( ! Objects.equals(id, projectDTO.id)) { return false; }
-
-        return true;
+        return Objects.equals(id, projectDTO.id);
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceDTO.java
@@ -12,6 +12,8 @@ import java.util.UUID;
  */
 public class SourceDTO implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private Long id;
 
     private UUID sourceId;

--- a/src/main/java/org/radarcns/management/service/dto/SourceDataDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceDataDTO.java
@@ -12,6 +12,8 @@ import java.util.Objects;
  */
 public class SourceDataDTO implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private Long id;
 
     //Source data type.

--- a/src/main/java/org/radarcns/management/service/dto/SourceTypeDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SourceTypeDTO.java
@@ -13,6 +13,8 @@ import org.radarcns.management.domain.enumeration.SourceTypeScope;
  */
 public class SourceTypeDTO implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private Long id;
 
     @NotNull
@@ -148,9 +150,9 @@ public class SourceTypeDTO implements Serializable {
 
         SourceTypeDTO sourceTypeDTO = (SourceTypeDTO) o;
 
-        if ( ! Objects.equals(id, sourceTypeDTO.id)) { return false; }
+        if ( id == null || sourceTypeDTO.id == null ) { return false; }
 
-        return true;
+        return Objects.equals(id, sourceTypeDTO.id);
     }
 
     @Override
@@ -178,9 +180,6 @@ public class SourceTypeDTO implements Serializable {
         private String producer;
         private String model;
         private String version;
-
-        public SourceTypeId() {
-        }
 
         public SourceTypeId producer(String producer) {
             this.producer = producer;

--- a/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/SubjectDTO.java
@@ -9,12 +9,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import javax.validation.constraints.Size;
 
 /**
  * A DTO for the Subject entity.
  */
 public class SubjectDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public enum SubjectStatus {
         DEACTIVATED,    // activated = false, removed = false
@@ -159,9 +160,9 @@ public class SubjectDTO implements Serializable {
 
         SubjectDTO subjectDTO = (SubjectDTO) o;
 
-        if ( ! Objects.equals(id, subjectDTO.id)) { return false; }
+        if ( id == null || subjectDTO.id == null ) { return false; }
 
-        return true;
+        return ! Objects.equals(id, subjectDTO.id);
     }
 
     @Override

--- a/src/main/java/org/radarcns/management/service/mapper/RoleMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/RoleMapper.java
@@ -2,7 +2,6 @@ package org.radarcns.management.service.mapper;
 
 
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.radarcns.management.domain.Authority;

--- a/src/main/java/org/radarcns/management/service/mapper/SourceDataMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/SourceDataMapper.java
@@ -2,7 +2,6 @@ package org.radarcns.management.service.mapper;
 
 import java.util.List;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.radarcns.management.domain.SourceData;
 import org.radarcns.management.service.dto.SourceDataDTO;
 

--- a/src/main/java/org/radarcns/management/service/mapper/UserMapper.java
+++ b/src/main/java/org/radarcns/management/service/mapper/UserMapper.java
@@ -1,16 +1,14 @@
 package org.radarcns.management.service.mapper;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.radarcns.management.domain.Authority;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.service.dto.UserDTO;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Mapper for the entity User and its DTO UserDTO.

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SourceMapperDecorator.java
@@ -1,13 +1,11 @@
 package org.radarcns.management.service.mapper.decorator;
 
+import java.util.Optional;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.repository.SourceRepository;
 import org.radarcns.management.service.dto.MinimalSourceDetailsDTO;
 import org.radarcns.management.service.mapper.SourceMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-
-import java.util.Optional;
 
 /**
  * Created by nivethika on 13-6-17.

--- a/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
+++ b/src/main/java/org/radarcns/management/service/mapper/decorator/SubjectMapperDecorator.java
@@ -128,6 +128,9 @@ public abstract class SubjectMapperDecorator implements SubjectMapper {
             case INVALID:
                 subject.getUser().setActivated(true);
                 subject.setRemoved(true);
+                break;
+            default:
+                break;
         }
         return subject;
     }

--- a/src/main/java/org/radarcns/management/web/rest/AuditResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AuditResource.java
@@ -33,7 +33,7 @@ import static org.radarcns.management.security.SecurityUtils.getJWT;
 public class AuditResource {
 
     @Autowired
-    HttpServletRequest servletRequest;
+    private HttpServletRequest servletRequest;
 
     @Autowired
     private AuditEventService auditEventService;

--- a/src/main/java/org/radarcns/management/web/rest/AuthorityResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/AuthorityResource.java
@@ -1,22 +1,20 @@
 package org.radarcns.management.web.rest;
 
+import static org.radarcns.auth.authorization.Permission.AUTHORITY_READ;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
+import static org.radarcns.management.security.SecurityUtils.getJWT;
+
 import com.codahale.metrics.annotation.Timed;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
-import org.radarcns.management.repository.AuthorityRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.radarcns.auth.authorization.Permission.AUTHORITY_READ;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
-import static org.radarcns.management.security.SecurityUtils.getJWT;
 
 /**
  * REST controller for managing Authority.
@@ -27,9 +25,6 @@ public class AuthorityResource {
 
     @Autowired
     private HttpServletRequest servletRequest;
-
-    @Autowired
-    private AuthorityRepository authorityRepository;
 
     private final Logger log = LoggerFactory.getLogger(AuthorityResource.class);
 

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -206,8 +206,10 @@ public class OAuthClientsResource {
         try {
             ClientDetails existing = clientDetailsService.loadClientByClientId(clientDetailsDTO
                     .getClientId());
-            throw new CustomConflictException("An OAuth client with that ID already exists",
+            if(Objects.nonNull(existing)) {
+                throw new CustomConflictException("An OAuth client with that ID already exists",
                     Collections.singletonMap("client_id", clientDetailsDTO.getClientId()));
+            }
         } catch (NoSuchClientException ex) {
             // Client does not exist yet, we can go ahead and create it
         }

--- a/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/OAuthClientsResource.java
@@ -204,12 +204,12 @@ public class OAuthClientsResource {
         checkClientFields(clientDetailsDTO);
         // check if the client id exists
         try {
-            ClientDetails existing = clientDetailsService.loadClientByClientId(clientDetailsDTO
+            clientDetailsService.loadClientByClientId(clientDetailsDTO
                     .getClientId());
-            if(Objects.nonNull(existing)) {
-                throw new CustomConflictException("An OAuth client with that ID already exists",
+            // throw exception if a client already exist with a given id
+            throw new CustomConflictException("An OAuth client with that ID already exists",
                     Collections.singletonMap("client_id", clientDetailsDTO.getClientId()));
-            }
+
         } catch (NoSuchClientException ex) {
             // Client does not exist yet, we can go ahead and create it
         }

--- a/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/ProjectResource.java
@@ -1,12 +1,28 @@
 package org.radarcns.management.web.rest;
 
+import static org.radarcns.auth.authorization.Permission.PROJECT_CREATE;
+import static org.radarcns.auth.authorization.Permission.PROJECT_DELETE;
+import static org.radarcns.auth.authorization.Permission.PROJECT_READ;
+import static org.radarcns.auth.authorization.Permission.PROJECT_UPDATE;
+import static org.radarcns.auth.authorization.Permission.ROLE_READ;
+import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
+import static org.radarcns.auth.authorization.Permission.SUBJECT_READ;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
+import static org.radarcns.management.security.SecurityUtils.getJWT;
+
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
-import org.radarcns.auth.authorization.Permission;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Subject;
 import org.radarcns.management.repository.SubjectRepository;
-import org.radarcns.management.security.SecurityUtils;
 import org.radarcns.management.service.ProjectService;
 import org.radarcns.management.service.RoleService;
 import org.radarcns.management.service.SourceService;
@@ -14,7 +30,6 @@ import org.radarcns.management.service.dto.ProjectDTO;
 import org.radarcns.management.service.dto.RoleDTO;
 import org.radarcns.management.service.dto.SourceTypeDTO;
 import org.radarcns.management.service.dto.SubjectDTO;
-import org.radarcns.management.service.mapper.SourceMapper;
 import org.radarcns.management.service.mapper.SubjectMapper;
 import org.radarcns.management.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
@@ -30,24 +45,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static org.radarcns.auth.authorization.Permission.PROJECT_CREATE;
-import static org.radarcns.auth.authorization.Permission.PROJECT_DELETE;
-import static org.radarcns.auth.authorization.Permission.PROJECT_READ;
-import static org.radarcns.auth.authorization.Permission.PROJECT_UPDATE;
-import static org.radarcns.auth.authorization.Permission.ROLE_READ;
-import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
-import static org.radarcns.management.security.SecurityUtils.getJWT;
 
 /**
  * REST controller for managing Project.
@@ -77,9 +74,6 @@ public class ProjectResource {
 
     @Autowired
     private SourceService sourceService;
-
-    @Autowired
-    private SourceMapper sourceMapper;
 
     /**
      * POST  /projects : Create a new project.
@@ -251,7 +245,7 @@ public class ProjectResource {
     @GetMapping("/projects/{projectName:" + Constants.ENTITY_ID_REGEX + "}/subjects")
     @Timed
     public ResponseEntity<List<SubjectDTO>> getAllSubjects(@PathVariable String projectName) {
-        checkPermissionOnProject(SecurityUtils.getJWT(servletRequest), Permission.SUBJECT_READ,
+        checkPermissionOnProject(getJWT(servletRequest), SUBJECT_READ,
             projectName);
         log.debug("REST request to get all subjects for project {}", projectName);
         List<Subject> subjects = subjectRepository.findAllByProjectName(projectName);

--- a/src/main/java/org/radarcns/management/web/rest/SourceResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SourceResource.java
@@ -1,12 +1,23 @@
 package org.radarcns.management.web.rest;
 
+import static org.radarcns.auth.authorization.Permission.SOURCE_CREATE;
+import static org.radarcns.auth.authorization.Permission.SOURCE_DELETE;
+import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
+import static org.radarcns.auth.authorization.Permission.SOURCE_UPDATE;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
+import static org.radarcns.management.security.SecurityUtils.getJWT;
+
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.repository.SourceRepository;
-import org.radarcns.management.service.ProjectService;
 import org.radarcns.management.service.SourceService;
-import org.radarcns.management.service.SourceTypeService;
 import org.radarcns.management.service.dto.SourceDTO;
 import org.radarcns.management.web.rest.util.HeaderUtil;
 import org.slf4j.Logger;
@@ -21,20 +32,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Optional;
-
-import static org.radarcns.auth.authorization.Permission.SOURCE_CREATE;
-import static org.radarcns.auth.authorization.Permission.SOURCE_DELETE;
-import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
-import static org.radarcns.auth.authorization.Permission.SOURCE_UPDATE;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
-import static org.radarcns.management.security.SecurityUtils.getJWT;
 
 /**
  * REST controller for managing Source.
@@ -54,13 +51,7 @@ public class SourceResource {
     private SourceRepository sourceRepository;
 
     @Autowired
-    private SourceTypeService sourceTypeService;
-
-    @Autowired
     private HttpServletRequest servletRequest;
-
-    @Autowired
-    private ProjectService projectService;
 
     /**
      * POST  /sources : Create a new source.

--- a/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/SubjectResource.java
@@ -1,11 +1,27 @@
 package org.radarcns.management.web.rest;
 
+import static org.radarcns.auth.authorization.Permission.SUBJECT_CREATE;
+import static org.radarcns.auth.authorization.Permission.SUBJECT_DELETE;
+import static org.radarcns.auth.authorization.Permission.SUBJECT_READ;
+import static org.radarcns.auth.authorization.Permission.SUBJECT_UPDATE;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
+import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnSubject;
+import static org.radarcns.management.security.SecurityUtils.getJWT;
+
 import com.codahale.metrics.annotation.Timed;
 import io.github.jhipster.web.util.ResponseUtil;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.servlet.http.HttpServletRequest;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
-import org.radarcns.auth.authorization.Permission;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.SourceType;
@@ -37,24 +53,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.servlet.http.HttpServletRequest;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import static org.radarcns.auth.authorization.Permission.SUBJECT_CREATE;
-import static org.radarcns.auth.authorization.Permission.SUBJECT_DELETE;
-import static org.radarcns.auth.authorization.Permission.SUBJECT_READ;
-import static org.radarcns.auth.authorization.Permission.SUBJECT_UPDATE;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
-import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnSubject;
-import static org.radarcns.management.security.SecurityUtils.getJWT;
 
 /**
  * REST controller for managing Subject.
@@ -216,7 +214,7 @@ public class SubjectResource {
     public ResponseEntity<List<SubjectDTO>> getAllSubjects(
             @RequestParam(value = "projectName", required = false) String projectName,
             @RequestParam(value = "externalId", required = false) String externalId) {
-        checkPermission(SecurityUtils.getJWT(servletRequest), Permission.SUBJECT_READ);
+        checkPermission(getJWT(servletRequest), SUBJECT_READ);
         log.debug("ProjectName {} and external {}", projectName, externalId);
         if (projectName != null && externalId != null) {
             Subject subject = subjectRepository

--- a/src/main/java/org/radarcns/management/web/rest/UserResource.java
+++ b/src/main/java/org/radarcns/management/web/rest/UserResource.java
@@ -165,12 +165,12 @@ public class UserResource {
                 .body(null);
         }
 
-        Optional<Subject> subject = subjectRepository.findOneWithEagerBySubjectLogin(managedUserVM.getLogin());
-        if (subject.isPresent()) {
+        Optional<Subject> subject = subjectRepository
+            .findOneWithEagerBySubjectLogin(managedUserVM.getLogin());
+        if (subject.isPresent() && managedUserVM.isActivated() && subject.get().isRemoved()) {
             // if the subject is also a user, check if the removed/activated states are valid
-            if (managedUserVM.isActivated() && subject.get().isRemoved()) {
-                throw new CustomParameterizedException("error.invalidsubjectstate");
-            }
+            throw new CustomParameterizedException("error.invalidsubjectstate");
+
         }
 
         Optional<UserDTO> updatedUser = userService.updateUser(managedUserVM);

--- a/src/main/java/org/radarcns/management/web/rest/vm/ManagedUserVM.java
+++ b/src/main/java/org/radarcns/management/web/rest/vm/ManagedUserVM.java
@@ -1,13 +1,10 @@
 package org.radarcns.management.web.rest.vm;
 
-import org.radarcns.management.domain.Project;
-import org.radarcns.management.service.dto.ProjectDTO;
-import org.radarcns.management.service.dto.RoleDTO;
-import org.radarcns.management.service.dto.UserDTO;
-import javax.validation.constraints.Size;
-
 import java.time.ZonedDateTime;
 import java.util.Set;
+import javax.validation.constraints.Size;
+import org.radarcns.management.service.dto.RoleDTO;
+import org.radarcns.management.service.dto.UserDTO;
 
 /**
  * View Model extending the UserDTO, which is meant to be used in the user management UI.

--- a/src/test/java/org/radarcns/management/cucumber/stepdefs/UserStepDefs.java
+++ b/src/test/java/org/radarcns/management/cucumber/stepdefs/UserStepDefs.java
@@ -1,32 +1,27 @@
 package org.radarcns.management.cucumber.stepdefs;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-
+import javax.servlet.ServletException;
 import org.radarcns.management.security.JwtAuthenticationFilter;
 import org.radarcns.management.web.rest.OAuthHelper;
+import org.radarcns.management.web.rest.UserResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import org.radarcns.management.web.rest.UserResource;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 public class UserStepDefs extends StepDefs {
 
     @Autowired
     private UserResource userResource;
-
-    @Autowired
-    private HttpServletRequest servletRequest;
 
     private MockMvc restUserMockMvc;
 
@@ -39,20 +34,20 @@ public class UserStepDefs extends StepDefs {
     }
 
     @When("^I search user '(.*)'$")
-    public void i_search_user_admin(String userId) throws Throwable {
+    public void iSearchUserAdmin(String userId) throws Throwable {
         actions = restUserMockMvc.perform(get("/api/users/" + userId)
                 .accept(MediaType.APPLICATION_JSON));
     }
 
     @Then("^the user is found$")
-    public void the_user_is_found() throws Throwable {
+    public void theUserIsFound() throws Throwable {
         actions
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));
     }
 
     @Then("^his last name is '(.*)'$")
-    public void his_last_name_is(String lastName) throws Throwable {
+    public void hisLastNameIs(String lastName) throws Throwable {
         actions.andExpect(jsonPath("$.lastName").value(lastName));
     }
 

--- a/src/test/java/org/radarcns/management/service/RedcapIntegrationWorkFlowOnServiceLevelTest.java
+++ b/src/test/java/org/radarcns/management/service/RedcapIntegrationWorkFlowOnServiceLevelTest.java
@@ -82,6 +82,8 @@ public class RedcapIntegrationWorkFlowOnServiceLevelTest {
                 case ProjectDTO.PHASE_KEY :
                     phaseRetrieved = attributeMapDTO.getValue();
                     break;
+                default:
+                    break;
             }
         }
 
@@ -109,8 +111,7 @@ public class RedcapIntegrationWorkFlowOnServiceLevelTest {
 
         // asset human-readable-id
         for (Map.Entry<String, String> attr : savedSubject.getAttributes().entrySet()) {
-            switch (attr.getKey()) {
-                case SubjectDTO.HUMAN_READABLE_IDENTIFIER_KEY :
+            if(SubjectDTO.HUMAN_READABLE_IDENTIFIER_KEY .equals(attr.getKey())){
                     assertEquals(humanReadableId, attr.getValue());
             }
         }

--- a/src/test/java/org/radarcns/management/web/rest/AccountResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/AccountResourceIntTest.java
@@ -23,7 +23,6 @@ import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.domain.Authority;
 import org.radarcns.management.domain.Role;
 import org.radarcns.management.domain.User;
-import org.radarcns.management.repository.AuthorityRepository;
 import org.radarcns.management.repository.UserRepository;
 import org.radarcns.management.service.MailService;
 import org.radarcns.management.service.UserService;
@@ -52,9 +51,6 @@ public class AccountResourceIntTest {
     private UserRepository userRepository;
 
     @Autowired
-    private AuthorityRepository authorityRepository;
-
-    @Autowired
     private UserService userService;
 
     @Autowired
@@ -69,7 +65,7 @@ public class AccountResourceIntTest {
     private MockMvc restUserMockMvc;
 
     @Before
-    public void setup() {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
         doNothing().when(mockMailService).sendActivationEmail(anyObject());
 

--- a/src/test/java/org/radarcns/management/web/rest/AuditResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/AuditResourceIntTest.java
@@ -72,7 +72,7 @@ public class AuditResourceIntTest {
     private MockMvc restAuditMockMvc;
 
     @Before
-    public void setup() throws ServletException {
+    public void setUp() throws ServletException {
         MockitoAnnotations.initMocks(this);
         AuditEventService auditEventService =
             new AuditEventService(auditEventRepository, auditEventConverter);

--- a/src/test/java/org/radarcns/management/web/rest/LogsResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/LogsResourceIntTest.java
@@ -29,7 +29,7 @@ public class LogsResourceIntTest {
     private MockMvc restLogsMockMvc;
 
     @Before
-    public void setup() {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
 
         LogsResource logsResource = new LogsResource();

--- a/src/test/java/org/radarcns/management/web/rest/OAuthClientsResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/OAuthClientsResourceIntTest.java
@@ -1,5 +1,21 @@
 package org.radarcns.management.web.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,24 +43,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
-import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Test class for the ProjectResource REST controller.
@@ -83,9 +81,6 @@ public class OAuthClientsResourceIntTest {
     private ExceptionTranslator exceptionTranslator;
 
     @Autowired
-    private EntityManager em;
-
-    @Autowired
     private HttpServletRequest servletRequest;
 
     private MockMvc restProjectMockMvc;
@@ -95,7 +90,7 @@ public class OAuthClientsResourceIntTest {
     int databaseSizeBeforeCreate;
 
     @Before
-    public void setup() throws Exception {
+    public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         OAuthClientsResource oauthClientsResource = new OAuthClientsResource();
         ReflectionTestUtils.setField(oauthClientsResource,

--- a/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/SourceResourceIntTest.java
@@ -25,7 +25,6 @@ import org.radarcns.management.ManagementPortalTestApp;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.repository.SourceRepository;
 import org.radarcns.management.security.JwtAuthenticationFilter;
-import org.radarcns.management.service.ProjectService;
 import org.radarcns.management.service.SourceService;
 import org.radarcns.management.service.SourceTypeService;
 import org.radarcns.management.service.dto.SourceDTO;
@@ -77,9 +76,6 @@ public class SourceResourceIntTest {
     private SourceService sourceService;
 
     @Autowired
-    private ProjectService projectService;
-
-    @Autowired
     private SourceTypeService sourceTypeService;
 
     @Autowired
@@ -111,7 +107,6 @@ public class SourceResourceIntTest {
         ReflectionTestUtils.setField(sourceResource, "servletRequest", servletRequest);
         ReflectionTestUtils.setField(sourceResource, "sourceService", sourceService);
         ReflectionTestUtils.setField(sourceResource, "sourceRepository", sourceRepository);
-        ReflectionTestUtils.setField(sourceResource, "projectService", projectService);
 
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter();
         filter.init(new MockFilterConfig());


### PR DESCRIPTION
This allows Codacy to check the main project code base for style as well. The `ignoreFailures` property has been set to `true` so tests won't fail because of incorrect style. We might enable it later when we have synced the complete codebase to the style.