### PR TITLE
Remove long constructors of UserDTO and ManagedUserVM

### DIFF
--- a/src/main/java/org/radarcns/management/service/dto/UserDTO.java
+++ b/src/main/java/org/radarcns/management/service/dto/UserDTO.java
@@ -1,11 +1,12 @@
 package org.radarcns.management.service.dto;
 
-import java.time.ZonedDateTime;
-import java.util.Set;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 import org.hibernate.validator.constraints.Email;
 import org.radarcns.auth.config.Constants;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.time.ZonedDateTime;
+import java.util.Set;
 
 /**
  * A DTO representing a user, with his authorities.
@@ -47,25 +48,6 @@ public class UserDTO {
 
     public UserDTO() {
         // Empty constructor needed for MapStruct.
-    }
-
-    public UserDTO(Long id, String login, String firstName, String lastName,
-        String email, boolean activated, String langKey,
-        String createdBy, ZonedDateTime createdDate, String lastModifiedBy, ZonedDateTime lastModifiedDate,
-        Set<RoleDTO> roles) {
-
-        this.id = id;
-        this.login = login;
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.email = email;
-        this.activated = activated;
-        this.langKey = langKey;
-        this.createdBy = createdBy;
-        this.createdDate = createdDate;
-        this.lastModifiedBy = lastModifiedBy;
-        this.lastModifiedDate = lastModifiedDate;
-        this.roles = roles;
     }
 
     public Long getId() {

--- a/src/main/java/org/radarcns/management/web/rest/vm/ManagedUserVM.java
+++ b/src/main/java/org/radarcns/management/web/rest/vm/ManagedUserVM.java
@@ -1,10 +1,8 @@
 package org.radarcns.management.web.rest.vm;
 
-import java.time.ZonedDateTime;
-import java.util.Set;
-import javax.validation.constraints.Size;
-import org.radarcns.management.service.dto.RoleDTO;
 import org.radarcns.management.service.dto.UserDTO;
+
+import javax.validation.constraints.Size;
 
 /**
  * View Model extending the UserDTO, which is meant to be used in the user management UI.
@@ -22,19 +20,12 @@ public class ManagedUserVM extends UserDTO {
         // Empty constructor needed for Jackson.
     }
 
-    public ManagedUserVM(Long id, String login, String password, String firstName, String lastName,
-                         String email, boolean activated, String langKey,
-                         String createdBy, ZonedDateTime createdDate, String lastModifiedBy, ZonedDateTime lastModifiedDate,
-                        Set<RoleDTO> roles) {
-
-        super(id, login, firstName, lastName, email, activated, langKey,
-            createdBy, createdDate, lastModifiedBy, lastModifiedDate,  roles);
-
-        this.password = password;
-    }
-
     public String getPassword() {
         return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     @Override

--- a/src/test/java/org/radarcns/management/web/rest/AccountResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/AccountResourceIntTest.java
@@ -87,21 +87,21 @@ public class AccountResourceIntTest {
     @Test
     public void testNonAuthenticatedUser() throws Exception {
         restUserMockMvc.perform(get("/api/authenticate")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(""));
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
     }
 
     @Test
     public void testAuthenticatedUser() throws Exception {
         restUserMockMvc.perform(get("/api/authenticate")
-            .with(request -> {
-                request.setRemoteUser("test");
-                return request;
-            })
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string("test"));
+                .with(request -> {
+                    request.setRemoteUser("test");
+                    return request;
+                })
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("test"));
     }
 
     @Test
@@ -111,10 +111,7 @@ public class AccountResourceIntTest {
         Authority authority = new Authority();
         authority.setName(AuthoritiesConstants.SYS_ADMIN);
         role.setAuthority(authority);
-//        Authority authority2 = new Authority();
-//        authority2.setName(AuthoritiesConstants.SYS_ADMIN);
         roles.add(role);
-//        authorities.add(authority2);
 
         User user = new User();
         user.setLogin("test");
@@ -126,15 +123,15 @@ public class AccountResourceIntTest {
         when(mockUserService.getUserWithAuthorities()).thenReturn(user);
 
         restUserMockMvc.perform(get("/api/account")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.login").value("test"))
-            .andExpect(jsonPath("$.firstName").value("john"))
-            .andExpect(jsonPath("$.lastName").value("doe"))
-            .andExpect(jsonPath("$.email").value("john.doe@jhipster.com"))
-            .andExpect(jsonPath("$.langKey").value("en"))
-            .andExpect(jsonPath("$.authorities").value(AuthoritiesConstants.SYS_ADMIN));
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(jsonPath("$.login").value("test"))
+                .andExpect(jsonPath("$.firstName").value("john"))
+                .andExpect(jsonPath("$.lastName").value("doe"))
+                .andExpect(jsonPath("$.email").value("john.doe@jhipster.com"))
+                .andExpect(jsonPath("$.langKey").value("en"))
+                .andExpect(jsonPath("$.authorities").value(AuthoritiesConstants.SYS_ADMIN));
     }
 
     @Test
@@ -142,8 +139,8 @@ public class AccountResourceIntTest {
         when(mockUserService.getUserWithAuthorities()).thenReturn(null);
 
         restUserMockMvc.perform(get("/api/account")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound());
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -154,25 +151,19 @@ public class AccountResourceIntTest {
         role.setAuthorityName(AuthoritiesConstants.PARTICIPANT);
         roles.add(role);
 
-        UserDTO invalidUser = new UserDTO(
-            null,                   // id
-            "funky-log!n",          // login <-- invalid
-            "Funky",                // firstName
-            "One",                  // lastName
-            "funky@example.com",    // email
-            true,                   // activated
-            "en",                   // langKey
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            roles);
+        UserDTO invalidUser = new UserDTO();
+        invalidUser.setLogin("funky-log!n");          // invalid login
+        invalidUser.setFirstName("Funky");
+        invalidUser.setLastName("One");
+        invalidUser.setEmail("funky@example.com");
+        invalidUser.setActivated(true);
+        invalidUser.setLangKey("en");
+        invalidUser.setRoles(roles);
 
-        restUserMockMvc.perform(
-            post("/api/account")
+        restUserMockMvc.perform(post("/api/account")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(invalidUser)))
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
 
         Optional<User> user = userRepository.findOneByEmail("funky@example.com");
         assertThat(user.isPresent()).isFalse();

--- a/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
+++ b/src/test/java/org/radarcns/management/web/rest/UserResourceIntTest.java
@@ -356,7 +356,7 @@ public class UserResourceIntTest {
 
         ManagedUserVM managedUserVM = new ManagedUserVM();
         managedUserVM.setId(updatedUser.getId());
-        managedUserVM.setLogin(updatedUser.getLogin());
+        managedUserVM.setLogin(UPDATED_LOGIN);
         managedUserVM.setPassword(UPDATED_PASSWORD);
         managedUserVM.setFirstName(UPDATED_FIRSTNAME);
         managedUserVM.setLastName(UPDATED_LASTNAME);


### PR DESCRIPTION
Did not refactor to a builder pattern since there are only a few test cases where these classes are initialized 'manually'. In the main code base they are always initialized by Jackson and/or MapStruct.

Closes #174 