### PR TITLE
Remove unused authorities field from User and drop associated table

### DIFF
--- a/src/main/java/org/radarcns/management/domain/User.java
+++ b/src/main/java/org/radarcns/management/domain/User.java
@@ -89,16 +89,6 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @Column(name = "reset_date")
     private ZonedDateTime resetDate = null;
 
-    @JsonIgnore
-    @ManyToMany()
-    @JoinTable(
-        name = "radar_user_authority",
-        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
-        inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    @BatchSize(size = 20)
-    private Set<Authority> authorities = new HashSet<>();
-
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
         name = "role_users",

--- a/src/main/java/org/radarcns/management/repository/UserRepository.java
+++ b/src/main/java/org/radarcns/management/repository/UserRepository.java
@@ -1,8 +1,5 @@
 package org.radarcns.management.repository;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.radarcns.management.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +7,10 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Spring Data JPA repository for the User entity.
@@ -26,28 +27,22 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findOneByLogin(String login);
 
-    @EntityGraph(attributePaths = "authorities")
-    User findOneWithAuthoritiesById(Long id);
-
-    @EntityGraph(attributePaths = "authorities")
-    Optional<User> findOneWithAuthoritiesByLogin(String login);
-
     @EntityGraph(attributePaths = "roles")
     Optional<User> findOneWithRolesByLogin(String login);
 
     Page<User> findAllByLoginNot(Pageable pageable, String login);
 
     @Query("select user from User user join user.roles roles "
-        + " where roles.project.projectName = :projectName "
-        + " and roles.authority.name = :authority")
+            + " where roles.project.projectName = :projectName "
+            + " and roles.authority.name = :authority")
     Page<User> findAllByProjectNameAndAuthority(Pageable pageable,
-        @Param("projectName") String projectName, @Param("authority") String authority);
+            @Param("projectName") String projectName, @Param("authority") String authority);
 
     @Query("select user from User user join user.roles roles "
-        + " where roles.authority.name = :authority")
+            + "where roles.authority.name = :authority")
     Page<User> findAllByAuthority(Pageable pageable, @Param("authority") String authority);
 
     @Query("select user from User user join user.roles roles "
-        + " where roles.project.projectName = :projectName ")
+            + " where roles.project.projectName = :projectName ")
     Page<User> findAllByProjectName(Pageable pageable, String projectName);
 }

--- a/src/main/java/org/radarcns/management/security/DomainUserDetailsService.java
+++ b/src/main/java/org/radarcns/management/security/DomainUserDetailsService.java
@@ -34,18 +34,19 @@ public class DomainUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(final String login) {
         log.debug("Authenticating {}", login);
         String lowercaseLogin = login.toLowerCase(Locale.ENGLISH);
-        Optional<User> userFromDatabase = userRepository.findOneWithAuthoritiesByLogin(lowercaseLogin);
+        Optional<User> userFromDatabase = userRepository.findOneWithRolesByLogin(lowercaseLogin);
         return userFromDatabase.map(user -> {
             if (!user.getActivated()) {
-                throw new UserNotActivatedException("User " + lowercaseLogin + " was not activated");
+                throw new UserNotActivatedException("User " + lowercaseLogin
+                        + " was not activated");
             }
             List<GrantedAuthority> grantedAuthorities = user.getAuthorities().stream()
                     .map(authority -> new SimpleGrantedAuthority(authority.getName()))
-                .collect(Collectors.toList());
+                    .collect(Collectors.toList());
             return new org.springframework.security.core.userdetails.User(lowercaseLogin,
-                user.getPassword(),
-                grantedAuthorities);
-        }).orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not found in the " +
-        "database"));
+                    user.getPassword(),
+                    grantedAuthorities);
+        }).orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not "
+                + "found in the database"));
     }
 }

--- a/src/main/java/org/radarcns/management/service/UserService.java
+++ b/src/main/java/org/radarcns/management/service/UserService.java
@@ -1,12 +1,5 @@
 package org.radarcns.management.service;
 
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.config.Constants;
 import org.radarcns.management.domain.Project;
@@ -32,6 +25,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Service class for managing users.
@@ -66,40 +67,40 @@ public class UserService {
     public Optional<User> activateRegistration(String key) {
         log.debug("Activating user for activation key {}", key);
         return userRepository.findOneByActivationKey(key)
-            .map(user -> {
-                // activate given user for the registration key.
-                user.setActivated(true);
-                user.setActivationKey(null);
-                log.debug("Activated user: {}", user);
-                return user;
-            });
+                .map(user -> {
+                    // activate given user for the registration key.
+                    user.setActivated(true);
+                    user.setActivationKey(null);
+                    log.debug("Activated user: {}", user);
+                    return user;
+                });
     }
 
     public Optional<User> completePasswordReset(String newPassword, String key) {
         log.debug("Reset user password for reset key {}", key);
 
         return userRepository.findOneByResetKey(key)
-            .filter(user -> {
-                ZonedDateTime oneDayAgo = ZonedDateTime.now().minusHours(24);
-                return user.getResetDate().isAfter(oneDayAgo);
-            })
-            .map(user -> {
-                user.setPassword(passwordEncoder.encode(newPassword));
-                user.setResetKey(null);
-                user.setResetDate(null);
-                user.setActivated(true);
-                return user;
-            });
+                .filter(user -> {
+                    ZonedDateTime oneDayAgo = ZonedDateTime.now().minusHours(24);
+                    return user.getResetDate().isAfter(oneDayAgo);
+                })
+                .map(user -> {
+                    user.setPassword(passwordEncoder.encode(newPassword));
+                    user.setResetKey(null);
+                    user.setResetDate(null);
+                    user.setActivated(true);
+                    return user;
+                });
     }
 
     public Optional<User> requestPasswordReset(String mail) {
         return userRepository.findOneByEmail(mail)
-            .filter(User::getActivated)
-            .map(user -> {
-                user.setResetKey(RandomUtil.generateResetKey());
-                user.setResetDate(ZonedDateTime.now());
-                return user;
-            });
+                .filter(User::getActivated)
+                .map(user -> {
+                    user.setResetKey(RandomUtil.generateResetKey());
+                    user.setResetDate(ZonedDateTime.now());
+                    return user;
+                });
     }
 
     public User createUser(UserDTO userDTO) {
@@ -128,8 +129,7 @@ public class UserService {
     private Set<Role> getUserRoles(UserDTO userDTO) {
         Set<Role> roles = new HashSet<>();
         for (RoleDTO roleDTO : userDTO.getRoles()) {
-            Role role = roleRepository
-                .findOneByProjectIdAndAuthorityName(roleDTO.getProjectId(),
+            Role role = roleRepository.findOneByProjectIdAndAuthorityName(roleDTO.getProjectId(),
                     roleDTO.getAuthorityName());
             if (role == null || role.getId() == null) {
                 Role currentRole = new Role();
@@ -175,22 +175,22 @@ public class UserService {
      */
     public Optional<UserDTO> updateUser(UserDTO userDTO) {
         return Optional.of(userRepository
-            .findOne(userDTO.getId()))
-            .map(user -> {
-                user.setLogin(userDTO.getLogin());
-                user.setFirstName(userDTO.getFirstName());
-                user.setLastName(userDTO.getLastName());
-                user.setEmail(userDTO.getEmail());
-                user.setActivated(userDTO.isActivated());
-                user.setLangKey(userDTO.getLangKey());
-                Set<Role> managedRoles = user.getRoles();
-                managedRoles.clear();
-                managedRoles.addAll(getUserRoles(userDTO));
+                .findOne(userDTO.getId()))
+                .map(user -> {
+                    user.setLogin(userDTO.getLogin());
+                    user.setFirstName(userDTO.getFirstName());
+                    user.setLastName(userDTO.getLastName());
+                    user.setEmail(userDTO.getEmail());
+                    user.setActivated(userDTO.isActivated());
+                    user.setLangKey(userDTO.getLangKey());
+                    Set<Role> managedRoles = user.getRoles();
+                    managedRoles.clear();
+                    managedRoles.addAll(getUserRoles(userDTO));
 
-                log.debug("Changed Information for User: {}", user);
-                return user;
-            })
-            .map(userMapper::userToUserDTO);
+                    log.debug("Changed Information for User: {}", user);
+                    return user;
+                })
+                .map(userMapper::userToUserDTO);
     }
 
     public void deleteUser(String login) {
@@ -212,12 +212,12 @@ public class UserService {
     public Page<UserDTO> getAllManagedUsers(Pageable pageable) {
         log.debug("Request to get all Users");
         return userRepository.findAllByLoginNot(pageable, Constants.ANONYMOUS_USER)
-            .map(userMapper::userToUserDTO);
+                .map(userMapper::userToUserDTO);
         }
 
     @Transactional(readOnly = true)
     public Optional<UserDTO> getUserWithAuthoritiesByLogin(String login) {
-        return userRepository.findOneWithAuthoritiesByLogin(login).map(userMapper::userToUserDTO);
+        return userRepository.findOneWithRolesByLogin(login).map(userMapper::userToUserDTO);
     }
 
     @Transactional(readOnly = true)
@@ -239,14 +239,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public User getUserWithAuthorities(Long id) {
-        return userRepository.findOneWithAuthoritiesById(id);
-    }
-
-    @Transactional(readOnly = true)
     public User getUserWithAuthorities() {
-        return userRepository.findOneWithAuthoritiesByLogin(SecurityUtils.getCurrentUserLogin())
-            .orElse(null);
+        return userRepository.findOneWithRolesByLogin(SecurityUtils.getCurrentUserLogin())
+                .orElse(null);
     }
 
 
@@ -260,7 +255,7 @@ public class UserService {
     public void removeNotActivatedUsers() {
         ZonedDateTime now = ZonedDateTime.now();
         List<User> users = userRepository
-            .findAllByActivatedIsFalseAndCreatedDateBefore(now.minusDays(3));
+                .findAllByActivatedIsFalseAndCreatedDateBefore(now.minusDays(3));
         for (User user : users) {
             log.debug("Deleting not activated user {}", user.getLogin());
             userRepository.delete(user);
@@ -270,16 +265,16 @@ public class UserService {
     public Page<UserDTO> findAllByProjectNameAndAuthority(Pageable pageable, String projectName,
             String authority) {
         return userRepository.findAllByProjectNameAndAuthority(pageable, projectName, authority)
-            .map(userMapper::userToUserDTO);
+                .map(userMapper::userToUserDTO);
     }
 
     public Page<UserDTO> findAllByAuthority(Pageable pageable, String authority) {
         return userRepository.findAllByAuthority(pageable, authority)
-            .map(userMapper::userToUserDTO);
+                .map(userMapper::userToUserDTO);
     }
 
     public Page<UserDTO> findAllByProjectName(Pageable pageable, String projectName) {
         return userRepository.findAllByProjectName(pageable, projectName)
-            .map(userMapper::userToUserDTO);
+                .map(userMapper::userToUserDTO);
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20171220155600_drop_table_radar_user_authority.xml
+++ b/src/main/resources/config/liquibase/changelog/20171220155600_drop_table_radar_user_authority.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017. The Hyve and respective contributors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~
+  ~ See the file LICENSE in the root of this repository.
+  ~
+  -->
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="20171220155600-0" author="dverbeec@its.jnj.com">
+        <dropTable cascadeConstraints="true"
+                   tableName="radar_user_authority"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -21,5 +21,6 @@
     <include file="classpath:config/liquibase/changelog/00000000000013_added_entity_constraints_Role.xml" relativeToChangelogFile="false"/>
 
     <include file="classpath:config/liquibase/changelog/00000000000014_added_demo_data.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20171220155600_drop_table_radar_user_authority.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>


### PR DESCRIPTION
We still need the `authorities` field in `UserDTO`. The frontend does a request to `/api/account` to get user information, and based on that it decides if you are an admin or not. We might want to change this behavior so that it uses the information in the JWT directly instead of making the extra call.

Closes #173 