### PR TITLE
Oauth2 client synchronized

### DIFF
--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
@@ -86,7 +86,7 @@ public class OAuth2Client {
         return currentToken;
     }
 
-    public synchronized OkHttpClient getHttpClient() {
+    public OkHttpClient getHttpClient() {
         if (httpClient == null) {
             // create a client which will supply OAuth client id and secret as HTTP basic authentication
             httpClient = new OkHttpClient.Builder()

--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
@@ -1,5 +1,10 @@
 package org.radarcns.oauth;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
 import okhttp3.FormBody;
@@ -8,12 +13,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
 import org.radarcns.exception.TokenException;
-
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Class for handling OAuth2 client credentials grant with the RADAR platform's ManagementPortal.
@@ -89,14 +88,14 @@ public class OAuth2Client {
         return currentToken;
     }
 
-    public OkHttpClient getHttpClient() {
+    public static synchronized OkHttpClient getHttpClient() {
         if (HTTP_CLIENT == null) {
             // create a client which will supply OAuth client id and secret as HTTP basic authentication
             HTTP_CLIENT = new OkHttpClient.Builder()
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .writeTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .build();
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(30, TimeUnit.SECONDS)
+                    .build();
         }
         return HTTP_CLIENT;
     }

--- a/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
+++ b/oauth-client-util/src/main/java/org/radarcns/oauth/OAuth2Client.java
@@ -33,7 +33,7 @@ public class OAuth2Client {
     private Set<String> scope;
     private OAuth2AccessTokenDetails currentToken;
 
-    private OkHttpClient HTTP_CLIENT;
+    private OkHttpClient httpClient;
 
     public OAuth2Client() {
         this.tokenEndpoint = null;
@@ -87,19 +87,19 @@ public class OAuth2Client {
     }
 
     public synchronized OkHttpClient getHttpClient() {
-        if (HTTP_CLIENT == null) {
+        if (httpClient == null) {
             // create a client which will supply OAuth client id and secret as HTTP basic authentication
-            HTTP_CLIENT = new OkHttpClient.Builder()
+            httpClient = new OkHttpClient.Builder()
                     .connectTimeout(10, TimeUnit.SECONDS)
                     .writeTimeout(10, TimeUnit.SECONDS)
                     .readTimeout(30, TimeUnit.SECONDS)
                     .build();
         }
-        return HTTP_CLIENT;
+        return httpClient;
     }
 
     public OAuth2Client httpClient(OkHttpClient httpClient) {
-        HTTP_CLIENT = httpClient;
+        this.httpClient = httpClient;
         return this;
     }
 

--- a/src/main/docker/etc/config/oauth_client_details.csv
+++ b/src/main/docker/etc/config/oauth_client_details.csv
@@ -4,4 +4,4 @@ aRMT;res_ManagementPortal,res_gateway;secret;MEASUREMENT.CREATE,SUBJECT.UPDATE,S
 THINC-IT;res_ManagementPortal,res_gateway;secret;MEASUREMENT.CREATE,SUBJECT.UPDATE,SUBJECT.READ,PROJECT.READ,SOURCETYPE.READ,SOURCE.READ,SOURCETYPE.READ,SOURCEDATA.READ,USER.READ,ROLE.READ;refresh_token,authorization_code;;;43200;7948800;{"dynamic_registration": true};
 radar_restapi;res_ManagementPortal;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};
 radar_redcap_integrator;res_ManagementPortal;secret;PROJECT.READ,SUBJECT.CREATE,SUBJECT.READ,SUBJECT.UPDATE;client_credentials;;;43200;259200;{};
-radar_dashboard;res_ManagementPortal,res_restApi;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};
+radar_dashboard;res_ManagementPortal,res_RestApi;secret;SUBJECT.READ,PROJECT.READ,SOURCE.READ,SOURCETYPE.READ;client_credentials;;;43200;259200;{};


### PR DESCRIPTION
Creates separate instances of HTTP-Clients per OAuth2Clients. Correctly updates `Authorization` header.
Fixes #185 