### PR TITLE
Refactor radar-auth

### DIFF
--- a/radar-auth/README.md
+++ b/radar-auth/README.md
@@ -47,9 +47,8 @@ Usage
 Once you have configured your project and have your configuration file in place, you can use the 
 `TokenValidator` class to validate and decode incoming tokens. It is recommended to have only one
 instance of this class in your application. Use the `validateAccessToken()` method to validate and
-decode a client access token. This library builds on Auth0's [Java-JWT] library, and the
-`validateAccessToken()` method returns a [`DecodedJWT`] object that contains all the information of
-the original JWT.
+decode a client access token. This library builds on Auth0's [Java-JWT] library for token 
+validation.
 
 To check for permissions, you can use the `RadarAuthorization` class. You can check permissions in
 three ways, depending on your use case. You pass the `DecodedJWT` object obtained from the 
@@ -77,5 +76,4 @@ first validate and decode the token, and then add it to the servlet context. Sub
 use the decoded token for further decision making.
 
 [Java-JWT]: https://github.com/auth0/java-jwt
-[`DecodedJWT`]: https://www.javadoc.io/doc/com.auth0/java-jwt/3.2.0/DecodedJWT.html
 [literal style]: http://www.yaml.org/spec/1.2/spec.html#id2795688

--- a/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authentication/TokenValidator.java
@@ -20,10 +20,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.radarcns.auth.authorization.RadarAuthorization;
 import org.radarcns.auth.config.ServerConfig;
 import org.radarcns.auth.config.YamlServerConfig;
 import org.radarcns.auth.exception.TokenValidationException;
+import org.radarcns.auth.token.JwtRadarToken;
+import org.radarcns.auth.token.RadarToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class TokenValidator {
     protected static final Logger log = LoggerFactory.getLogger(TokenValidator.class);
     // additional required claims apart from the required JWT claims
     protected static final List<String> REQUIRED_CLAIMS = Arrays.asList(
-            RadarAuthorization.GRANT_TYPE_CLAIM, RadarAuthorization.SCOPE_CLAIM);
+            JwtRadarToken.GRANT_TYPE_CLAIM, JwtRadarToken.SCOPE_CLAIM);
 
     private final ServerConfig config;
     private JWTVerifier verifier;
@@ -100,7 +101,7 @@ public class TokenValidator {
      * @return The decoded access token
      * @throws TokenValidationException If the token can not be validated.
      */
-    public DecodedJWT validateAccessToken(String token) throws TokenValidationException {
+    public RadarToken validateAccessToken(String token) throws TokenValidationException {
         try {
             DecodedJWT jwt = getVerifier().verify(token);
             Set<String> claims = jwt.getClaims().keySet();
@@ -111,7 +112,7 @@ public class TokenValidator {
                 throw new TokenValidationException("The following required claims were missing "
                         + "from the token: " + String.join(", ", missing));
             }
-            return jwt;
+            return new JwtRadarToken(jwt);
         } catch (SignatureVerificationException sve) {
             log.warn("Client presented a token with an incorrect signature, fetching public key"
                     + " again. Token: {}", token);

--- a/radar-auth/src/main/java/org/radarcns/auth/authorization/Permission.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authorization/Permission.java
@@ -118,6 +118,15 @@ public class Permission {
     }
 
     /**
+     * Check if a given authority has this permission associated with it.
+     * @param authority the authority name
+     * @return true if the given authority has this permission associated with it, false otherwise
+     */
+    public boolean isAuthorityAllowed(String authority) {
+        return Permissions.allowedAuthorities(this).contains(authority);
+    }
+
+    /**
      * Get all currently defined permissions.
      * @return A list containing all currently defined permissions
      */
@@ -167,7 +176,7 @@ public class Permission {
     }
 
     /**
-     * Turn this permission into an OAuth scope name and return it
+     * Turn this permission into an OAuth scope name and return it.
      *
      * @return the OAuth scope representation of this permission
      */

--- a/radar-auth/src/main/java/org/radarcns/auth/authorization/RadarAuthorization.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/authorization/RadarAuthorization.java
@@ -1,11 +1,7 @@
 package org.radarcns.auth.authorization;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.radarcns.auth.exception.NotAuthorizedException;
+import org.radarcns.auth.token.RadarToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,55 +13,50 @@ import org.slf4j.LoggerFactory;
 public class RadarAuthorization {
 
     private static final Logger log = LoggerFactory.getLogger(RadarAuthorization.class);
-    public static final String AUTHORITIES_CLAIM = "authorities";
-    public static final String ROLES_CLAIM = "roles";
-    public static final String SCOPE_CLAIM = "scope";
-    public static final String SOURCES_CLAIM = "sources";
-    public static final String GRANT_TYPE_CLAIM = "grant_type";
-    private static final String CLIENT_CREDENTIALS = "client_credentials";
 
     /**
-     * Check if the user authenticated with the given token has the given permission. Not taking
-     * into account project affiliations. Throws a {@link NotAuthorizedException} if the supplied
-     * token does not have the permission.
-     * @param token The token of the logged in user
+     * Similar to {@link RadarToken#hasPermission(Permission)}, but this method throws an
+     * exception rather than returning a boolean. Useful in combination with e.g. Spring's
+     * controllers and exception translators.
+     * @param token The token of the authenticated client
      * @param permission The permission to check
      * @throws NotAuthorizedException if the supplied token does not have the permission
      */
-    public static void checkPermission(DecodedJWT token, Permission permission)
+    public static void checkPermission(RadarToken token, Permission permission)
             throws NotAuthorizedException {
-        log.debug("Checking permission {} for user {}", permission.toString(), token.getSubject());
-        checkScope(token, permission);
-        if (!isClientCredentials(token)) {
-            // it's not a client_credentials token, so we need both scope and authority
-            checkPermission(token, permission, getAuthorities(token));
+        log.debug("Checking permission {} for user {}", permission.toString(),
+                token.getSubject());
+        if (!token.hasPermission(permission)) {
+            throw new NotAuthorizedException(String.format("Client %s does not have "
+                    + "permission %s", token.getSubject(), permission.toString()));
         }
     }
 
     /**
-     * Check if the user authenticated with the given token has the given permission in a project.
-     * Throws a {@link NotAuthorizedException} if the supplied token does not have the permission
-     * in the given project.
+     * Similar to {@link RadarToken#hasPermissionOnProject(Permission, String)}, but this method
+     * throws an exception rather than returning a boolean. Useful in combination with e.g. Spring's
+     * controllers and exception translators.
      * @param token The token of the logged in user
      * @param permission The permission to check
      * @param projectName The project for which to check the permission
      * @throws NotAuthorizedException if the supplied token does not have the permission in the
      *     given project
      */
-    public static void checkPermissionOnProject(DecodedJWT token, Permission permission,
+    public static void checkPermissionOnProject(RadarToken token, Permission permission,
             String projectName) throws NotAuthorizedException {
         log.debug("Checking permission {} for user {} in project {}", permission.toString(),
                 token.getSubject(), projectName);
-        checkScope(token, permission);
-        if (!isClientCredentials(token)) {
-            checkPermission(token, permission, getAuthoritiesForProject(token, projectName));
+        if (!token.hasPermissionOnProject(permission, projectName)) {
+            throw new NotAuthorizedException(String.format("Client %s does not have "
+                    + "permission %s in project %s", token.getSubject(), permission.toString(),
+                    projectName));
         }
     }
 
     /**
-     * Check if the user authenticated with the given token has the given permission on a specific
-     * subject in a project. Throws a {@link NotAuthorizedException} if the supplied token does
-     * not have the permission in the given project for the given subject.
+     * Similar to {@link RadarToken#hasPermissionOnSubject(Permission, String, String)}, but this
+     * method throws an exception rather than returning a boolean. Useful in combination with e.g.
+     * Spring's controllers and exception translators.
      * @param token The token of the logged in user
      * @param permission The permission to check
      * @param projectName The project for which to check the permission
@@ -73,107 +64,14 @@ public class RadarAuthorization {
      * @throws NotAuthorizedException if the supplied token does not have the permission in the
      *     given project for the given subject
      */
-    public static void checkPermissionOnSubject(DecodedJWT token, Permission permission,
+    public static void checkPermissionOnSubject(RadarToken token, Permission permission,
             String projectName, String subjectName) throws NotAuthorizedException {
         log.debug("Checking permission {} for user {} on subject {} in project {}",
                 permission.toString(), token.getSubject(), subjectName, projectName);
-        checkScope(token, permission);
-        if (!isClientCredentials(token)) {
-            // we're allowed to read our own data
-            if (token.getSubject().equals(subjectName) && Permissions.allowedAuthorities(permission)
-                    .contains(AuthoritiesConstants.PARTICIPANT)) {
-                return;
-            }
-
-            // if we're only a participant, and we're not the subject we request data for,
-            // we don't have access
-            if (isJustParticipant(token, projectName)) {
-                throw new NotAuthorizedException(String.format("User %s does not have permission"
-                        + " %s in project %s for subject %s", token.getSubject(),
-                        permission.toString(), projectName, subjectName));
-            } else {
-                // otherwise we have other roles and we should check on a project level
-                checkPermission(token, permission, getAuthoritiesForProject(token, projectName));
-            }
-        }
-    }
-
-    /**
-     * Check if this user is just a participant in the project.
-     * @param token Token of the authenticated user
-     * @param projectName Project to check
-     * @return true if PARTICIPANT is the only authority of the user in the project, false otherwise
-     */
-    public static boolean isJustParticipant(DecodedJWT token, String projectName) {
-        if (!token.getClaims().containsKey(ROLES_CLAIM)) {
-            return false;
-        }
-        List<String> roles = token.getClaim(ROLES_CLAIM).asList(String.class).stream()
-                .filter(r -> r.startsWith(projectName + ":"))
-                .collect(Collectors.toList());
-        return roles.size() == 1 && roles.get(0).equals(projectName + ":"
-                + AuthoritiesConstants.PARTICIPANT);
-    }
-
-    private static Set<String> getAuthoritiesForProject(DecodedJWT token, String projectName) {
-        // get all project-based authorities
-        Set<String> result = token.getClaims().containsKey(ROLES_CLAIM)
-                ? token.getClaim(ROLES_CLAIM).asList(String.class).stream()
-                        .filter(s -> s.startsWith(projectName + ":"))
-                        .map(s -> s.split(":")[1])
-                        .collect(Collectors.toSet())
-                : new HashSet<>();
-        // also add SYS_ADMIN authority if we have it
-        if (token.getClaims().containsKey(AUTHORITIES_CLAIM)
-                && token.getClaim(AUTHORITIES_CLAIM).asList(String.class)
-                .contains(AuthoritiesConstants.SYS_ADMIN)) {
-            result.add(AuthoritiesConstants.SYS_ADMIN);
-        }
-        return result;
-    }
-
-    private static boolean hasScope(DecodedJWT token, Permission permission) {
-        return token.getClaim(SCOPE_CLAIM).asList(String.class).contains(permission.scopeName());
-    }
-
-    protected static void checkPermission(DecodedJWT token, Permission permission,
-            Set<String> authsGranted) throws NotAuthorizedException {
-        // Take intersection of both sets
-        authsGranted.retainAll(Permissions.allowedAuthorities(permission));
-        if (authsGranted.isEmpty()) {
-            log.info("User {} does not have permission {}", token.getSubject(),
-                    permission.toString());
-            throw new NotAuthorizedException(String.format("User %s does not have permission %s",
-                    token.getSubject(), permission.toString()));
-        }
-    }
-
-    private static Set<String> getAuthorities(DecodedJWT token) {
-        Set<String> result = new HashSet<>();
-        // get all project-based authorities
-        if (token.getClaims().containsKey(ROLES_CLAIM)) {
-            result.addAll(token.getClaim(ROLES_CLAIM).asList(String.class).stream().filter(s -> s
-                    .contains(":"))
-                    .map(s -> s.split(":")[1]).collect(Collectors.toSet()));
-        }
-        // also add non-project based authorities
-        if (token.getClaims().containsKey(AUTHORITIES_CLAIM)) {
-            result.addAll(token.getClaim(AUTHORITIES_CLAIM).asList(String.class));
-        }
-        return result;
-    }
-
-    private static void checkScope(DecodedJWT token, Permission permission)
-            throws NotAuthorizedException {
-        if (hasScope(token, permission)) {
-            return;
-        } else {
+        if (!token.hasPermissionOnSubject(permission, projectName, subjectName)) {
             throw new NotAuthorizedException(String.format("Client %s does not have "
-                    + "permission %s", token.getSubject(), permission.toString()));
+                    + "permission %s on subject %s in project %s", token.getSubject(),
+                    permission.toString(), subjectName, projectName));
         }
-    }
-
-    private static boolean isClientCredentials(DecodedJWT token) {
-        return CLIENT_CREDENTIALS.equals(token.getClaim(GRANT_TYPE_CLAIM).asString());
     }
 }

--- a/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
@@ -1,0 +1,112 @@
+package org.radarcns.auth.token;
+
+import org.radarcns.auth.authorization.AuthoritiesConstants;
+import org.radarcns.auth.authorization.Permission;
+
+import java.util.Collections;
+
+/**
+ * Partial implementation of {@link RadarToken}, providing a default implementation for the three
+ * permission checks.
+ */
+public abstract class AbstractRadarToken implements RadarToken {
+
+    protected static final String CLIENT_CREDENTIALS = "client_credentials";
+
+    @Override
+    public boolean hasPermission(Permission permission) {
+        return hasScope(permission.scopeName())
+                && (isClientCredentials() || hasAuthorityForPermission(permission));
+
+    }
+
+    @Override
+    public boolean hasPermissionOnProject(Permission permission, String projectName) {
+        return hasScope(permission.scopeName())
+                && (isClientCredentials() || hasAuthorityForPermission(permission, projectName));
+    }
+
+    @Override
+    public boolean hasPermissionOnSubject(Permission permission, String projectName,
+            String subjectName) {
+        return hasScope(permission.scopeName())
+                && (isClientCredentials() || hasAuthorityForPermission(permission, projectName,
+                        subjectName));
+    }
+
+    protected boolean hasScope(String scope) {
+        return getScopes().contains(scope);
+    }
+
+    protected boolean isClientCredentials() {
+        return CLIENT_CREDENTIALS.equals(getGrantType());
+    }
+
+    /**
+     * Check all authorities in this token, project and non-project specific, for the given
+     * permission.
+     * @param permission the permission
+     * @return {@code true} if any authority contains the permission, {@code false} otherwise
+     */
+    protected boolean hasAuthorityForPermission(Permission permission) {
+        return getRoles().values().stream()
+                .flatMap(s -> s.stream())
+                .anyMatch(permission::isAuthorityAllowed)
+                || hasNonProjectRelatedAuthorityForPermission(permission);
+    }
+
+    /**
+     * Check authorities in this token linked to the given project, or not linked to any project
+     * (such as {@code SYS_ADMIN}), for the given permission.
+     * @param permission the permission
+     * @param projectName the project name
+     * @return {@code true} if any authority contains the permission, {@code false} otherwise
+     */
+    protected boolean hasAuthorityForPermission(Permission permission, String projectName) {
+        return getRoles().containsKey(projectName) && getRoles().get(projectName).stream()
+                .anyMatch(permission::isAuthorityAllowed)
+                || hasNonProjectRelatedAuthorityForPermission(permission);
+    }
+
+    /**
+     * Check authorities in this token linked to the given project, or not linked to any project
+     * (such as {@code SYS_ADMIN}), for the given permission on the given subject.
+     * @param permission the permission
+     * @param projectName the project name
+     * @param subjectName the subject name
+     * @return {@code true} if any authority contains the permission, {@code false} otherwise
+     */
+    protected boolean hasAuthorityForPermission(Permission permission, String projectName,
+            String subjectName) {
+        // if we're only a participant, we can only do operations on our own data
+        return (isJustParticipant(projectName) && getSubject().equals(subjectName)
+                && permission.isAuthorityAllowed(AuthoritiesConstants.PARTICIPANT))
+                // if we have other roles beside participant, we should check those on the
+                // project level
+                || (!isJustParticipant(projectName) && hasAuthorityForPermission(permission,
+                        projectName));
+    }
+
+    /**
+     * Check if any non-project related authority has the given permission. Currently the only
+     * non-project authority is {@code SYS_ADMIN}, so we only check for that.
+     * @param permission the permission
+     * @return {@code true} if any non-project related authority has the permission, {@code false}
+     *     otherwise
+     */
+    protected boolean hasNonProjectRelatedAuthorityForPermission(Permission permission) {
+        return getAuthorities().contains(AuthoritiesConstants.SYS_ADMIN)
+                && permission.isAuthorityAllowed(AuthoritiesConstants.SYS_ADMIN);
+    }
+
+    /**
+     * Check if this token only has the participant role in the given project.
+     * @param projectName the project
+     * @return {@code true} if this token only has the participant role in the given project,
+     *     {@code false} otherwise
+     */
+    protected boolean isJustParticipant(String projectName) {
+        return getRoles().containsKey(projectName) && getRoles().get(projectName)
+                .equals(Collections.singletonList(AuthoritiesConstants.PARTICIPANT));
+    }
+}

--- a/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
@@ -21,18 +21,18 @@ public class JwtRadarToken extends AbstractRadarToken {
     public static final String SOURCES_CLAIM = "sources";
     public static final String GRANT_TYPE_CLAIM = "grant_type";
 
-    private Map<String, List<String>> roles;
-    private List<String> authorities;
-    private List<String> scopes;
-    private List<String> sources;
-    private String grantType;
-    private String subject;
-    private Date issuedAt;
-    private Date expiresAt;
-    private List<String> audience;
-    private String token;
-    private String issuer;
-    private String type;
+    private final Map<String, List<String>> roles;
+    private final List<String> authorities;
+    private final List<String> scopes;
+    private final List<String> sources;
+    private final String grantType;
+    private final String subject;
+    private final Date issuedAt;
+    private final Date expiresAt;
+    private final List<String> audience;
+    private final String token;
+    private final String issuer;
+    private final String type;
 
     /**
      * Initialize this {@code JwtRadarToken} based on the {@link DecodedJWT}. All relevant

--- a/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
@@ -1,0 +1,161 @@
+package org.radarcns.auth.token;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link RadarToken} based on JWT tokens.
+ */
+public class JwtRadarToken extends AbstractRadarToken {
+
+    public static final String AUTHORITIES_CLAIM = "authorities";
+    public static final String ROLES_CLAIM = "roles";
+    public static final String SCOPE_CLAIM = "scope";
+    public static final String SOURCES_CLAIM = "sources";
+    public static final String GRANT_TYPE_CLAIM = "grant_type";
+
+    private Map<String, List<String>> roles;
+    private List<String> authorities;
+    private List<String> scopes;
+    private List<String> sources;
+    private String grantType;
+    private String subject;
+    private Date issuedAt;
+    private Date expiresAt;
+    private List<String> audience;
+    private String token;
+    private String issuer;
+    private String type;
+
+    /**
+     * Initialize this {@code JwtRadarToken} based on the {@link DecodedJWT}. All relevant
+     * information will be parsed at construction time and no reference to the {@link DecodedJWT}
+     * is kept. Therefore, modifying the passed in {@link DecodedJWT} after this has been
+     * constructed will <strong>not</strong> update this object.
+     * @param jwt the JWT token to use to initialize this object
+     */
+    public JwtRadarToken(DecodedJWT jwt) {
+        roles = parseRoles(jwt);
+        authorities = parseAuthorities(jwt);
+        scopes = parseScopes(jwt);
+        sources = parseSources(jwt);
+        grantType = parseGrantType(jwt);
+        subject = jwt.getSubject() == null ? "" : jwt.getSubject();
+        issuedAt = jwt.getIssuedAt();
+        expiresAt = jwt.getExpiresAt();
+        audience = jwt.getAudience() == null ? Collections.emptyList() : jwt.getAudience();
+        token = jwt.getToken() == null ? "" : jwt.getToken();
+        issuer = jwt.getIssuer() == null ? "" : jwt.getIssuer();
+        type = jwt.getType() == null ? "" : jwt.getType();
+    }
+
+    @Override
+    public Map<String, List<String>> getRoles() {
+        return roles;
+    }
+
+    @Override
+    public List<String> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    @Override
+    public List<String> getSources() {
+        return sources;
+    }
+
+    @Override
+    public String getGrantType() {
+        return grantType;
+    }
+
+    @Override
+    public String getSubject() {
+        return subject;
+    }
+
+    @Override
+    public Date getIssuedAt() {
+        return issuedAt;
+    }
+
+    @Override
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    @Override
+    public List<String> getAudience() {
+        return audience;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+
+    @Override
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    private Map<String, List<String>> parseRoles(DecodedJWT jwt) {
+        if (!jwt.getClaims().containsKey(ROLES_CLAIM)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, List<String>> result = new HashMap<>();
+        List<String[]> parsedRoles = jwt.getClaim(ROLES_CLAIM).asList(String.class).stream()
+                .filter(s -> s.contains(":"))
+                .map(s -> s.split(":"))
+                .collect(Collectors.toList());
+        for (String[] role : parsedRoles) {
+            if (!result.containsKey(role[0])) {
+                result.put(role[0], new LinkedList<>());
+            }
+            result.get(role[0]).add(role[1]);
+        }
+        return result;
+    }
+
+    private List<String> parseAuthorities(DecodedJWT jwt) {
+        return jwt.getClaims().containsKey(AUTHORITIES_CLAIM)
+                ? jwt.getClaim(AUTHORITIES_CLAIM).asList(String.class)
+                : Collections.emptyList();
+    }
+
+    private List<String> parseScopes(DecodedJWT jwt) {
+        return jwt.getClaims().containsKey(SCOPE_CLAIM)
+                ? jwt.getClaim(SCOPE_CLAIM).asList(String.class)
+                : Collections.emptyList();
+    }
+
+    private List<String> parseSources(DecodedJWT jwt) {
+        return jwt.getClaims().containsKey(SOURCES_CLAIM)
+                ? jwt.getClaim(SOURCES_CLAIM).asList(String.class)
+                : Collections.emptyList();
+    }
+
+    private String parseGrantType(DecodedJWT jwt) {
+        return jwt.getClaims().containsKey(GRANT_TYPE_CLAIM)
+                ? jwt.getClaim(GRANT_TYPE_CLAIM).asString()
+                : "";
+    }
+}

--- a/radar-auth/src/main/java/org/radarcns/auth/token/RadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/RadarToken.java
@@ -1,0 +1,117 @@
+package org.radarcns.auth.token;
+
+import org.radarcns.auth.authorization.Permission;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by dverbeec on 10/01/2018.
+ */
+public interface RadarToken {
+
+    /**
+     * Get the roles defined in this token.
+     * @return a map describing the roles defined in this token. The keys in the map are the
+     *     project names, and the values are lists of authority names associated to the project.
+     */
+    Map<String, List<String>> getRoles();
+
+    /**
+     * Get a list of non-project related authorities.
+     * @return a list of authority names
+     */
+    List<String> getAuthorities();
+
+    /**
+     * Get a list of scopes assigned to this token.
+     * @return a list of scope names
+     */
+    List<String> getScopes();
+
+    /**
+     * Get a list of source names associated with this token.
+     * @return a list of source names
+     */
+    List<String> getSources();
+
+    /**
+     * Get this token's OAuth2 grant type.
+     * @return the grant type
+     */
+    String getGrantType();
+
+    /**
+     * Get the token subject.
+     * @return the subject
+     */
+    String getSubject();
+
+    /**
+     * Get the date this token was issued.
+     * @return the date this token was issued
+     */
+    Date getIssuedAt();
+
+    /**
+     * Get the date this token expires.
+     * @return the date this token expires
+     */
+    Date getExpiresAt();
+
+    /**
+     * Get the audience of the token.
+     * @return the list of resources that are allowed to accept the token
+     */
+    List<String> getAudience();
+
+    /**
+     * Get a string representation of this token.
+     * @return the string representation of this token
+     */
+    String getToken();
+
+    /**
+     * Get the issuer.
+     * @return the issuer
+     */
+    String getIssuer();
+
+    /**
+     * Get the token type.
+     * @return the token type.
+     */
+    String getType();
+
+    /**
+     * Check if this token has the given permission, not taking into account project affiliations.
+     *
+     * <p>This token <strong>must</strong> have the permission in its set of scopes. If it's a
+     * client credentials token, this is the only requirement, as a client credentials token is
+     * linked to an OAuth client and not to a user in the system. If it's not a client
+     * credentials token, this also checks to see if the user has a role with the specified
+     * permission.</p>
+     * @param permission The permission to check
+     * @return {@code true} if this token has the permission, {@code false} otherwise
+     */
+    boolean hasPermission(Permission permission);
+
+    /**
+     * Check if this token has a permission in a specific project.
+     * @param permission the permission
+     * @param projectName the project name
+     * @return true if this token has the permission in the project, false otherwise
+     */
+    boolean hasPermissionOnProject(Permission permission, String projectName);
+
+    /**
+     * Check if this token has a permission on a subject in a given project.
+     * @param permission the permission
+     * @param projectName the project name
+     * @param subjectName the subject name
+     * @return true if this token ahs the permission for the subject in the given project, false
+     *     otherwise
+     */
+    boolean hasPermissionOnSubject(Permission permission, String projectName, String subjectName);
+}

--- a/radar-auth/src/test/java/org/radarcns/auth/unit/util/TokenTestUtils.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/unit/util/TokenTestUtils.java
@@ -226,6 +226,7 @@ public class TokenTestUtils {
     private static String[] allScopes() {
         return Permission.allPermissions().stream()
                 .map(Permission::scopeName)
-                .collect(Collectors.toList()).toArray(new String[Permission.allPermissions().size()]);
+                .collect(Collectors.toList())
+                .toArray(new String[Permission.allPermissions().size()]);
     }
 }

--- a/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
+++ b/src/main/java/org/radarcns/management/security/ClaimsTokenEnhancer.java
@@ -7,7 +7,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.radarcns.auth.authorization.RadarAuthorization;
+
+import org.radarcns.auth.token.JwtRadarToken;
 import org.radarcns.management.domain.Source;
 import org.radarcns.management.domain.User;
 import org.radarcns.management.repository.SubjectRepository;
@@ -41,7 +42,7 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
     @Value("${spring.application.name}")
     private String appName;
 
-    private final static String GRANT_TOKEN_EVENT = "GRANT_ACCESS_TOKEN";
+    private static final String GRANT_TOKEN_EVENT = "GRANT_ACCESS_TOKEN";
 
     @Override
     public OAuth2AccessToken enhance(OAuth2AccessToken accessToken,
@@ -62,7 +63,7 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
                         .map(role -> role.getProject().getProjectName() + ":"
                                 + role.getAuthority().getName())
                         .collect(Collectors.toList());
-                additionalInfo.put(RadarAuthorization.ROLES_CLAIM, roles);
+                additionalInfo.put(JwtRadarToken.ROLES_CLAIM, roles);
 
             }
 
@@ -71,12 +72,12 @@ public class ClaimsTokenEnhancer implements TokenEnhancer, InitializingBean {
             List<String> sourceIds = assignedSources.stream()
                     .map(s -> s.getSourceId().toString())
                     .collect(Collectors.toList());
-            additionalInfo.put(RadarAuthorization.SOURCES_CLAIM, sourceIds);
+            additionalInfo.put(JwtRadarToken.SOURCES_CLAIM, sourceIds);
         }
         // add iat and iss optional JWT claims
         additionalInfo.put("iat", Instant.now().getEpochSecond());
         additionalInfo.put("iss", appName);
-        additionalInfo.put(RadarAuthorization.GRANT_TYPE_CLAIM,
+        additionalInfo.put(JwtRadarToken.GRANT_TYPE_CLAIM,
                 authentication.getOAuth2Request().getGrantType());
         ((DefaultOAuth2AccessToken) accessToken)
                 .setAdditionalInformation(additionalInfo);

--- a/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/radarcns/management/security/JwtAuthenticationFilter.java
@@ -1,12 +1,5 @@
 package org.radarcns.management.security;
 
-import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.radarcns.auth.authentication.TokenValidator;
 import org.radarcns.auth.exception.TokenValidationException;
 import org.radarcns.management.config.LocalKeystoreConfig;
@@ -16,6 +9,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 /**
  * Created by dverbeec on 29/09/2017.

--- a/src/main/java/org/radarcns/management/security/SecurityUtils.java
+++ b/src/main/java/org/radarcns/management/security/SecurityUtils.java
@@ -1,12 +1,13 @@
 package org.radarcns.management.security;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
-import javax.servlet.ServletRequest;
+import org.radarcns.auth.token.RadarToken;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import javax.servlet.ServletRequest;
 
 /**
  * Utility class for Spring Security.
@@ -53,21 +54,21 @@ public final class SecurityUtils {
      * @param request servlet request
      * @return decoded JWT
      * @throws AccessDeniedException if the {@code "jwt"} attribute is missing or does not contain a
-     * decoded JWT
+     *     decoded JWT
      */
-    public static DecodedJWT getJWT(ServletRequest request) {
-        Object jwt = request.getAttribute(JwtAuthenticationFilter.TOKEN_ATTRIBUTE);
-        if (jwt == null) {
+    public static RadarToken getJWT(ServletRequest request) {
+        Object token = request.getAttribute(JwtAuthenticationFilter.TOKEN_ATTRIBUTE);
+        if (token == null) {
             // should not happen, the JwtAuthenticationFilter would throw an exception first if it
             // can not decode the authorization header into a valid JWT
             throw new AccessDeniedException("No token was found in the request context.");
         }
-        if (!(jwt instanceof DecodedJWT)) {
+        if (!(token instanceof RadarToken)) {
             // should not happen, the JwtAuthenticationFilter will only set a DecodedJWT object
-            throw new AccessDeniedException("Expected token to be of type DecodedJWT but was "
-                    + jwt.getClass().getName());
+            throw new AccessDeniedException("Expected token to be of type org.radarcns"
+                    + ".auth.token.RadarToken but was " + token.getClass().getName());
         }
-        return (DecodedJWT) jwt;
+        return (RadarToken) token;
     }
 
 


### PR DESCRIPTION
- The token implementation is now wrapped with a `RadarToken` interface
- The new `RadarToken` has methods to check for permissions and query custom claims
- `RadarAuthorization` is still there, but only keeps the `check...` methods
- The public static claim names are moved from `RadarAuthorization` to `JwtRadarToken`
- `Permission` class now has a method to check if a given authority has that permission
- `TokenValidator.validateAccessToken(String)` now returns a `RadarToken` so clients of this library should only have to deal with our wrapper of the token.

Closes #194, closes #195 