### PR TITLE
Add permission check methods java8

### DIFF
--- a/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
@@ -1,5 +1,6 @@
 package org.radarcns.auth.token;
 
+import java.util.Collection;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.authorization.Permission;
 
@@ -50,7 +51,7 @@ public abstract class AbstractRadarToken implements RadarToken {
      */
     protected boolean hasAuthorityForPermission(Permission permission) {
         return getRoles().values().stream()
-                .flatMap(s -> s.stream())
+                .flatMap(Collection::stream)
                 .anyMatch(permission::isAuthorityAllowed)
                 || hasNonProjectRelatedAuthorityForPermission(permission);
     }

--- a/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/AbstractRadarToken.java
@@ -1,6 +1,7 @@
 package org.radarcns.auth.token;
 
 import java.util.Collection;
+import java.util.Objects;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
 import org.radarcns.auth.authorization.Permission;
 
@@ -64,7 +65,7 @@ public abstract class AbstractRadarToken implements RadarToken {
      * @return {@code true} if any authority contains the permission, {@code false} otherwise
      */
     protected boolean hasAuthorityForPermission(Permission permission, String projectName) {
-        return getRoles().containsKey(projectName) && getRoles().get(projectName).stream()
+        return getRoles().getOrDefault(projectName, Collections.emptyList()).stream()
                 .anyMatch(permission::isAuthorityAllowed)
                 || hasNonProjectRelatedAuthorityForPermission(permission);
     }
@@ -107,7 +108,7 @@ public abstract class AbstractRadarToken implements RadarToken {
      *     {@code false} otherwise
      */
     protected boolean isJustParticipant(String projectName) {
-        return getRoles().containsKey(projectName) && getRoles().get(projectName)
-                .equals(Collections.singletonList(AuthoritiesConstants.PARTICIPANT));
+        return Objects.equals(getRoles().get(projectName),
+            Collections.singletonList(AuthoritiesConstants.PARTICIPANT));
     }
 }

--- a/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
+++ b/radar-auth/src/main/java/org/radarcns/auth/token/JwtRadarToken.java
@@ -120,12 +120,12 @@ public class JwtRadarToken extends AbstractRadarToken {
                 .distinct()
                 .map(s -> s.split(":"))
                 .collect(Collectors.toMap(
-                    s -> s[0],  // key
-                    s -> Collections.singletonList(s[1]),  // value
-                    (projects1, projects2) -> {  // merge
-                        List<String> merged = new ArrayList<>(projects1.size() + projects2.size());
-                        merged.addAll(projects1);
-                        merged.addAll(projects2);
+                    s -> s[0],  // project
+                    s -> Collections.singletonList(s[1]),  // role
+                    (roles1, roles2) -> {  // merge
+                        List<String> merged = new ArrayList<>(roles1.size() + roles2.size());
+                        merged.addAll(roles1);
+                        merged.addAll(roles2);
                         return merged;
                     }));
     }

--- a/radar-auth/src/test/java/org/radarcns/auth/unit/authorization/RadarAuthorizationTest.java
+++ b/radar-auth/src/test/java/org/radarcns/auth/unit/authorization/RadarAuthorizationTest.java
@@ -1,5 +1,6 @@
 package org.radarcns.auth.unit.authorization;
 
+import java.util.Map.Entry;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.radarcns.auth.authorization.AuthoritiesConstants;
@@ -33,7 +34,7 @@ public class RadarAuthorizationTest {
         // let's get all permissions a project admin has
         Set<Permission> permissions = Permissions.getPermissionMatrix().entrySet().stream()
                 .filter(e -> e.getValue().contains(AuthoritiesConstants.PROJECT_ADMIN))
-                .map(e -> e.getKey())
+                .map(Entry::getKey)
                 .collect(Collectors.toSet());
         RadarToken token = new JwtRadarToken(TokenTestUtils.PROJECT_ADMIN_TOKEN);
         for (Permission p : permissions) {
@@ -42,19 +43,18 @@ public class RadarAuthorizationTest {
 
         Set<Permission> notPermitted = Permissions.getPermissionMatrix().entrySet().stream()
                 .filter(e -> !e.getValue().contains(AuthoritiesConstants.PROJECT_ADMIN))
-                .map(e -> e.getKey())
+                .map(Entry::getKey)
                 .collect(Collectors.toSet());
 
-        notPermitted.stream()
-                .forEach(p -> {
-                    try {
-                        RadarAuthorization.checkPermissionOnProject(token, p, project);
-                    } catch (NotAuthorizedException ex) {
-                        return;
-                    }
-                    fail(String.format("Token should not have permission %s on project %s",
-                            p.toString(), project));
-                });
+        notPermitted.forEach(p -> {
+            try {
+                RadarAuthorization.checkPermissionOnProject(token, p, project);
+            } catch (NotAuthorizedException ex) {
+                return;
+            }
+            fail(String.format("Token should not have permission %s on project %s",
+                    p.toString(), project));
+        });
     }
 
     @Test


### PR DESCRIPTION
Some small Java 8 / notation tweaks:
- helper functions for empty string/list defaults
- directly use unspecified claims: it will return null after conversion to `asList` or `asString`.
- single stream function to parse the roles
- some lambda -> Function::ref changes