### PR TITLE
Detect Scala classpath properly

### DIFF
--- a/gradle/gatling.gradle
+++ b/gradle/gatling.gradle
@@ -15,6 +15,11 @@ dependencies {
     gatlingCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"
 }
 
+//noinspection GroovyAssignabilityCheck
+tasks.withType(ScalaCompile) {
+    scalaClasspath = scalaRuntime.inferScalaClasspath(configurations.gatlingCompile)
+}
+
 task manifestJar(type: Jar) {
     from configurations.gatlingCompile
     archiveName 'gatlingBooter.jar'


### PR DESCRIPTION
This prevents a warning in IDEA whenever the Gradle files reload.